### PR TITLE
Heuristic chord-block detection as the primary extraction strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,12 @@ DRIVE_FOLDER_ID=
 # Puppeteer: in the container we use the bundled Chromium. To point at a system
 # Chrome instead, set this to its absolute path.
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+
+# ── Scraping strategy ─────────────────────────────────────────────────────────
+# How the chord chart is located on the page:
+#   heuristic (default) — content-based scoring; resilient to UG DOM/class changes
+#   auto                — try the CSS selector first, fall back to the heuristic
+#   selector            — CSS selector only (legacy behavior)
+SCRAPE_STRATEGY=heuristic
+# Minimum score the heuristic must clear before it's trusted (tune if needed).
+DETECT_MIN_SCORE=5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,18 +32,29 @@ bash .konjo/scripts/install-hooks.sh   # install Wall 1 pre-commit hook
 - **`/scrape` is never open.** It requires the `x-api-key` shared-secret header and a validated
   `ultimate-guitar.com` URL.
 - **ESM + async/await throughout.** No callback-style Google API calls; await every promise.
-- **Selectors are config.** UG selectors live in `src/config.js` so they can be re-pinned when UG
-  changes its markup.
+- **Selectors are config, not the primary strategy.** Extraction is **heuristic-first**
+  (`src/detect.js` scores candidate text blocks by chord-content fingerprint), with the CSS selector
+  in `src/config.js` as a fallback. Strategy is env-switchable via `SCRAPE_STRATEGY`. Selectors are
+  still worth re-pinning when convenient, but a markup change no longer breaks the scrape.
+
+## How extraction works
+`src/scraper.js` resolves the chart via `extractChordText(page)` under `SCRAPE_STRATEGY`:
+- `heuristic` (default): content-based detector first; fall back to the selector if nothing clears
+  `DETECT_MIN_SCORE` (resilient to UG DOM/class-name churn).
+- `auto`: CSS selector first (fast, unambiguous when it works); fall back to the heuristic.
+- `selector`: selector only (exact legacy behavior — the escape hatch).
+Title/artist also fall back to parsing `document.title` when their selectors fail.
 
 ## Module Map
 | Module | Role |
 |--------|------|
 | `src/server.js` | Express app, routes, API-key guard, input validation |
-| `src/scraper.js` | `scrapeSong(url) -> { title, artist, rawText }` (Puppeteer, headless) |
+| `src/scraper.js` | `scrapeSong(url) -> { title, artist, rawText }` + `extractChordText` (strategy) |
+| `src/detect.js` | heuristic chord-block detection: pure scoring + Puppeteer glue (primary strategy) |
 | `src/formatter.js` | **Crown Jewels**: builds `batchUpdate` requests + second unbold pass (behavior-preserved) |
 | `src/google/auth.js` | OAuth2 client, `/auth` + `/oauth2callback`, refresh-token load |
 | `src/google/docs.js` | copy template, run `batchUpdate`, re-read doc for unbold pass |
-| `src/config.js` | env-driven config: templateId, folderId, scopes, selectors, port |
+| `src/config.js` | env-driven config: templateId, folderId, scopes, selectors, strategy, port |
 | `src/constants.js` | `sectionTitles[]`, `titles` regex source, `chords` regex source |
 
 ## Quality Framework

--- a/README.md
+++ b/README.md
@@ -21,17 +21,42 @@ Google with a stored OAuth refresh token (zero human interaction per run). Trigg
 ```
 src/
   server.js        Express app + routes + API-key guard + URL validation
-  scraper.js       scrapeSong(url) -> { title, artist, rawText }   (headless Puppeteer)
+  scraper.js       scrapeSong(url) -> { title, artist, rawText } + extractChordText (strategy)
+  detect.js        heuristic chord-block detection (content-fingerprint scoring) — primary strategy
   formatter.js     Crown Jewels: builds the batchUpdate requests + unbold second pass
   google/
     auth.js        OAuth2 client, /auth + /oauth2callback, refresh-token load
     docs.js        copy template, batchUpdate, unbold second pass (all awaited)
-  config.js        env-driven: templateId, folderId, scopes, selectors, port
+  config.js        env-driven: templateId, folderId, scopes, selectors, strategy, port
   constants.js     sectionTitles[], titles regex, chords regex
 test/
+  detect.test.js           heuristic scoring unit tests
+  scraper-strategy.test.js extractChordText strategy wiring (fake page, no browser)
   formatter.test.js        regression: refactored payload === legacy payload
   formatter.fixture.json   captured legacy batchUpdate payload (golden)
 ```
+
+## How extraction works
+
+The chord chart is located **heuristically by default** — `src/detect.js` scores candidate text
+blocks by their content fingerprint (chord density, section headers, chord-alignment whitespace) and
+picks the best one. This makes the scrape resilient to Ultimate Guitar's recurring DOM/class-name
+changes, the failure mode that breaks selector-based scraping. The exact CSS selector
+(`selectors.chordBlock` in `src/config.js`) is kept as a **fallback** (still fast and unambiguous when
+it works, and worth re-pinning when convenient).
+
+The strategy is env-switchable via `SCRAPE_STRATEGY` — the escape hatch if the heuristic ever
+misbehaves in production (flip the env var, no code change):
+
+| `SCRAPE_STRATEGY` | Behavior |
+|---|---|
+| `heuristic` (default) | heuristic first; fall back to the selector if nothing clears `DETECT_MIN_SCORE` |
+| `auto` | selector first; fall back to the heuristic if the selector is empty |
+| `selector` | selector only (exact legacy behavior) |
+
+`DETECT_MIN_SCORE` (default `5`) is the minimum chord-chart score the heuristic must clear to be
+trusted — a weak best-candidate is rejected rather than scraping the wrong element. Title/artist also
+fall back to parsing `document.title` when their selectors fail.
 
 ## Endpoints
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,9 @@ export default [
         Buffer: 'readonly',
         setTimeout: 'readonly',
         fetch: 'readonly',
+        // Browser global — used inside collectCandidatesInPage, which is serialized
+        // into the page by page.evaluate() and executes in the browser context.
+        document: 'readonly',
       },
     },
     rules: {

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,8 @@ const {
   TEMPLATE_DOC_ID,
   DRIVE_FOLDER_ID,
   PUPPETEER_EXECUTABLE_PATH,
+  SCRAPE_STRATEGY,
+  DETECT_MIN_SCORE,
 } = process.env;
 
 export const config = {
@@ -46,6 +48,12 @@ export const config = {
 
   // How long to wait for navigation/selectors before giving up (ms).
   scrapeTimeoutMs: 45_000,
+
+  // Extraction strategy: 'heuristic' (default, content-based, resilient to DOM
+  // changes), 'auto' (selector first, heuristic fallback), or 'selector' (legacy).
+  scrapeStrategy: SCRAPE_STRATEGY || 'heuristic',
+  // Minimum chord-chart score the heuristic must clear to be trusted.
+  detectMinScore: Number(DETECT_MIN_SCORE) || 5,
 };
 
 // Ultimate Guitar DOM selectors. These rot whenever UG ships a markup change.

--- a/src/detect.js
+++ b/src/detect.js
@@ -112,11 +112,15 @@ export function pickBestCandidate(candidates) {
  * self-contained — it is serialized into the page by page.evaluate().
  * @returns {Array<{ tag: string, text: string }>}
  */
-/* global document -- collectCandidatesInPage executes in the browser via page.evaluate */
-/* istanbul ignore next — runs in the browser, covered by live integration */
+/* istanbul ignore next — runs in the browser (via page.evaluate), covered by live integration */
 function collectCandidatesInPage() {
   const out = [];
   const seen = new Set();
+  /**
+   * Record an element's text as a candidate if it is multi-line and not huge.
+   * @param {Element} el
+   * @returns {void}
+   */
   const consider = (el) => {
     const text = el.innerText || el.textContent || '';
     if (!text) return;
@@ -169,7 +173,7 @@ export async function detectChordBlock(page, minScore = 0) {
  */
 export function parseTitleFromDocTitle(docTitle) {
   if (!docTitle) return null;
-  const m = docTitle.match(/^(.*?)\s+Chords?\s+by\s+(.*?)(?:\s*[@|].*)?$/i);
-  if (!m) return null;
-  return { title: m[1].trim(), artist: m[2].trim() };
+  const match = docTitle.match(/^(.*?)\s+Chords?\s+by\s+(.*?)(?:\s*[@|].*)?$/i);
+  if (!match) return null;
+  return { title: match[1].trim(), artist: match[2].trim() };
 }

--- a/src/detect.js
+++ b/src/detect.js
@@ -1,0 +1,175 @@
+// Heuristic fallback for locating the chord-chart text when the configured CSS
+// selector fails (e.g. Ultimate Guitar changes its DOM/class names). Instead of
+// a structural selector, we score candidate text blocks by their *content
+// fingerprint* — chord density, section headers, and chord-style whitespace —
+// and return the best match.
+//
+// The scoring functions are pure and unit-tested (test/detect.test.js).
+// detectChordBlock() is the thin Puppeteer glue around them.
+
+// A single whitespace-delimited token that looks like a chord. Anchored to the
+// whole token: root [A-G], optional accidental, optional quality, optional
+// extension number, optional second quality/tension, optional slash bass.
+// Anchoring + the [A-G] root start is what keeps most English words out:
+// "Bad"/"Cab"/"Face"/"Add" all fail because the 2nd char isn't a chord part.
+const CHORD_TOKEN =
+  /^[A-G](?:#|b)?(?:m|maj|min|dim|aug|sus|add|M)?\d{0,2}(?:sus|add|aug|dim)?\d{0,2}(?:\/[A-G](?:#|b)?)?$/;
+
+// Non-chord tokens that still belong to a chord line: repeat counts (x4),
+// no-chord marks, bar lines, and parenthesised passing notes.
+const ANNOTATION_TOKEN = /^(?:x\d{1,2}|N\.?C\.?|\|+|:|\([^)]*\))$/i;
+
+// A line that is a section header, with or without brackets.
+const SECTION_LINE =
+  /^\s*\[?(?:intro|verse|pre-?chorus|chorus|bridge|interlude|instrumental|solo|outro|riff|refrain|coda|hook|break|ending|tab|capo)\b[^\]]*\]?\s*$/i;
+
+/**
+ * Whether a single token reads as a chord (or a chord-line annotation).
+ * @param {string} token
+ * @returns {boolean}
+ */
+export function isChordToken(token) {
+  if (!token) return false;
+  return ANNOTATION_TOKEN.test(token) || CHORD_TOKEN.test(token);
+}
+
+/**
+ * Classify a single line as a section header, chord line, lyric, or blank.
+ * A line counts as chords when most of its tokens are chord-like, OR when it
+ * has multiple chord tokens spaced out for alignment (the classic chords-above-
+ * lyrics layout).
+ * @param {string} line
+ * @returns {'section'|'chord'|'lyric'|'blank'}
+ */
+export function classifyLine(line) {
+  if (SECTION_LINE.test(line)) return 'section';
+  const tokens = line.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return 'blank';
+
+  const chordish = tokens.filter(isChordToken).length;
+  const ratio = chordish / tokens.length;
+  const aligned = /\S\s{2,}\S/.test(line); // 2+ spaces between visible tokens
+
+  if (chordish >= 1 && ratio >= 0.5) return 'chord';
+  if (chordish >= 2 && aligned) return 'chord';
+  return 'lyric';
+}
+
+/**
+ * Score how chord-chart-like a block of text is. Higher is better; 0 means "not
+ * a chart". Section headers are weighted most (very distinctive), then chord
+ * lines, with a small bonus for alignment whitespace. Blocks with too little
+ * substance score 0 to avoid latching onto a stray two-line snippet.
+ * @param {string} text
+ * @returns {number}
+ */
+export function scoreChordText(text) {
+  if (!text) return 0;
+  const lines = text.split(/\r\n|\r|\n/);
+
+  let chord = 0;
+  let section = 0;
+  let aligned = 0;
+  let nonBlank = 0;
+
+  for (const line of lines) {
+    const kind = classifyLine(line);
+    if (kind !== 'blank') nonBlank += 1;
+    if (kind === 'chord') chord += 1;
+    else if (kind === 'section') section += 1;
+    if (/\S\s{2,}\S/.test(line)) aligned += 1;
+  }
+
+  if (nonBlank < 4) return 0;
+  if (chord === 0 && section === 0) return 0;
+  return chord * 2 + section * 3 + aligned;
+}
+
+/**
+ * Choose the best candidate block. Prefers the highest score; on a tie, prefers
+ * the *shorter* block, which tends to be the tightest element that still wraps
+ * the whole chart (rather than a parent container that also contains nav/ads).
+ * @param {Array<{ text: string, [k: string]: unknown }>} candidates
+ * @returns {({ text: string, score: number, [k: string]: unknown })|null}
+ */
+export function pickBestCandidate(candidates) {
+  let best = null;
+  for (const candidate of candidates) {
+    const score = scoreChordText(candidate.text);
+    if (score <= 0) continue;
+    const better =
+      !best ||
+      score > best.score ||
+      (score === best.score && candidate.text.length < best.text.length);
+    if (better) best = { ...candidate, score };
+  }
+  return best;
+}
+
+/**
+ * Browser-context collector. Gathers <pre> blocks plus leaf-ish text containers
+ * (few element children, multi-line text) as detection candidates. Must be
+ * self-contained — it is serialized into the page by page.evaluate().
+ * @returns {Array<{ tag: string, text: string }>}
+ */
+/* global document -- collectCandidatesInPage executes in the browser via page.evaluate */
+/* istanbul ignore next — runs in the browser, covered by live integration */
+function collectCandidatesInPage() {
+  const out = [];
+  const seen = new Set();
+  const consider = (el) => {
+    const text = el.innerText || el.textContent || '';
+    if (!text) return;
+    if (text.length > 20000) return; // too large — almost certainly a container
+    if (text.split('\n').length < 4) return;
+    if (seen.has(text)) return;
+    seen.add(text);
+    out.push({ tag: el.tagName.toLowerCase(), text });
+  };
+  document.querySelectorAll('pre').forEach(consider);
+  document.querySelectorAll('div, section, article, td').forEach((el) => {
+    if (el.childElementCount <= 3) consider(el);
+  });
+  return out;
+}
+
+/**
+ * Locate the chord-chart text on a page heuristically. Returns the raw text of
+ * the best-scoring block, or null if nothing clears `minScore`. The threshold is
+ * what lets this run as the *primary* strategy safely: a weak best-candidate is
+ * rejected (→ caller falls back to the CSS selector) rather than silently
+ * scraping the wrong block.
+ * @param {import('puppeteer').Page} page
+ * @param {number} [minScore=0] - reject the best candidate below this score
+ * @returns {Promise<string|null>}
+ */
+export async function detectChordBlock(page, minScore = 0) {
+  const candidates = await page.evaluate(collectCandidatesInPage);
+  const best = pickBestCandidate(candidates);
+  if (!best || best.score < minScore) {
+    if (best) {
+      console.warn(
+        `[detect] best candidate score ${best.score} < min ${minScore}; rejecting heuristic match.`
+      );
+    }
+    return null;
+  }
+  console.warn(
+    `[detect] heuristic matched a <${best.tag}> (score ${best.score}). ` +
+      'If the configured selector is stale, re-pin selectors.chordBlock in src/config.js.'
+  );
+  return best.text;
+}
+
+/**
+ * Fallback for title/artist from the document title, which UG formats as
+ * "<Song> Chords by <Artist> ...". Used when the title/artist selectors fail.
+ * @param {string} docTitle - document.title
+ * @returns {{ title: string, artist: string }|null}
+ */
+export function parseTitleFromDocTitle(docTitle) {
+  if (!docTitle) return null;
+  const m = docTitle.match(/^(.*?)\s+Chords?\s+by\s+(.*?)(?:\s*[@|].*)?$/i);
+  if (!m) return null;
+  return { title: m[1].trim(), artist: m[2].trim() };
+}

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -29,7 +29,9 @@ export async function extractChordText(
   strategy = config.scrapeStrategy,
   minScore = config.detectMinScore
 ) {
+  /** @returns {Promise<string>} the selector-sourced chord text, trimmed */
   const viaSelector = async () => (await readJoined(page, selectors.chordBlock)).trim();
+  /** @returns {Promise<string>} the heuristic-detected chord text, trimmed ('' if none) */
   const viaHeuristic = async () => ((await detectChordBlock(page, minScore)) ?? '').trim();
 
   if (strategy === 'selector') return viaSelector();
@@ -59,7 +61,7 @@ export async function scrapeSong(url) {
 
     await page.goto(url, { waitUntil: 'networkidle2' });
     // Best-effort: wait on the known render signal, but don't fail if it has rotted.
-    await page.waitForSelector(selectors.ready).catch(() => {});
+    await page.waitForSelector(selectors.ready).catch(() => null);
 
     const rawText = await extractChordText(page);
     const rawTitle = await readJoined(page, selectors.title);

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -4,6 +4,7 @@
 
 import puppeteer from 'puppeteer';
 import { config, selectors } from './config.js';
+import { detectChordBlock, parseTitleFromDocTitle } from './detect.js';
 
 /**
  * Read every match of `selector` and return the concatenated textContent.
@@ -14,6 +15,27 @@ import { config, selectors } from './config.js';
 async function readJoined(page, selector) {
   const parts = await page.$$eval(selector, (els) => els.map((el) => el.textContent));
   return parts.join('');
+}
+
+/**
+ * Resolve the chord-chart text using the configured strategy.
+ * @param {import('puppeteer').Page} page
+ * @param {string} [strategy=config.scrapeStrategy]
+ * @param {number} [minScore=config.detectMinScore]
+ * @returns {Promise<string>} the raw chart text, or '' if all paths fail
+ */
+export async function extractChordText(
+  page,
+  strategy = config.scrapeStrategy,
+  minScore = config.detectMinScore
+) {
+  const viaSelector = async () => (await readJoined(page, selectors.chordBlock)).trim();
+  const viaHeuristic = async () => ((await detectChordBlock(page, minScore)) ?? '').trim();
+
+  if (strategy === 'selector') return viaSelector();
+  if (strategy === 'auto') return (await viaSelector()) || viaHeuristic();
+  // 'heuristic' (default)
+  return (await viaHeuristic()) || viaSelector();
 }
 
 /**
@@ -35,22 +57,27 @@ export async function scrapeSong(url) {
     page.setDefaultTimeout(config.scrapeTimeoutMs);
     await page.setViewport({ width: 1350, height: 850 });
 
-    await page.goto(url, { waitUntil: 'domcontentloaded' });
-    // Wait for the chart to render instead of guessing with a timer.
-    await page.waitForSelector(selectors.ready);
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    // Best-effort: wait on the known render signal, but don't fail if it has rotted.
+    await page.waitForSelector(selectors.ready).catch(() => {});
 
-    const rawText = await readJoined(page, selectors.chordBlock);
+    const rawText = await extractChordText(page);
     const rawTitle = await readJoined(page, selectors.title);
     const rawArtist = await readJoined(page, selectors.artist);
 
     // Legacy cleaning: strip " Chords" from the title and "Edit" from the artist.
-    const title = rawTitle.replace(' Chords', '');
-    const artist = rawArtist.replace('Edit', '');
+    let title = rawTitle.replace(' Chords', '');
+    let artist = rawArtist.replace('Edit', '');
+    if (!title || !artist) {
+      const fromDoc = parseTitleFromDocTitle(await page.title());
+      if (fromDoc) ({ title, artist } = fromDoc);
+    }
 
     if (!rawText) {
       throw new Error(
-        'Scrape returned an empty chord block — the Ultimate Guitar selectors may have changed. ' +
-          'Re-pin them in src/config.js (selectors).'
+        'Scrape returned an empty chord block — the heuristic found nothing above threshold and ' +
+          'the Ultimate Guitar selectors may have changed. Re-pin them in src/config.js (selectors), ' +
+          'lower DETECT_MIN_SCORE, or set SCRAPE_STRATEGY=selector/auto.'
       );
     }
 

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -1,0 +1,124 @@
+import {
+  isChordToken,
+  classifyLine,
+  scoreChordText,
+  pickBestCandidate,
+  parseTitleFromDocTitle,
+} from '../src/detect.js';
+
+// A realistic chord chart (chords-above-lyrics, section headers).
+const CHART = `[Intro]
+G   D   Em   C
+
+[Verse 1]
+G                 D
+White lips, pale face
+Em                C
+Breathing in the snowflakes
+G               D
+Burning lungs, the city
+
+[Chorus]
+Em   C   G   D
+Oh, oh, oh
+Em   C       G   D
+You're my everything`;
+
+// Decoy 1: a prose bio that happens to mention notes/letters.
+const BIO = `Ed Sheeran is an English singer and songwriter.
+Born in Halifax and raised in Framlingham, he learned guitar
+at a young age and moved to London in 2008 to pursue music.
+He has sold more than 150 million records worldwide and is
+one of the best-selling music artists of his generation.`;
+
+// Decoy 2: a navigation / UI block.
+const NAV = `Home
+Explore
+Top Tabs
+Submit Tab
+Sign In
+Favorites
+Settings`;
+
+describe('isChordToken', () => {
+  it('accepts real chords incl. extensions and slash bass', () => {
+    for (const t of ['G', 'Am', 'C#m7', 'Dsus4', 'G/B', 'Cadd9', 'F#dim', 'N.C.', 'x4', '|']) {
+      expect(isChordToken(t)).toBe(true);
+    }
+  });
+
+  it('rejects A–G English words and lowercase tokens', () => {
+    for (const t of ['Bad', 'Cab', 'Add', 'Face', 'Dad', 'Bag', 'and', 'the', 'snowflakes']) {
+      expect(isChordToken(t)).toBe(false);
+    }
+  });
+});
+
+describe('classifyLine', () => {
+  it('detects section headers with and without brackets', () => {
+    expect(classifyLine('[Verse 1]')).toBe('section');
+    expect(classifyLine('Chorus')).toBe('section');
+  });
+  it('detects chord lines and lyric lines', () => {
+    expect(classifyLine('G   D   Em   C')).toBe('chord');
+    expect(classifyLine('Em   C       G   D')).toBe('chord');
+    expect(classifyLine('White lips, pale face')).toBe('lyric');
+  });
+});
+
+describe('scoreChordText', () => {
+  it('scores a real chart well above prose and nav decoys', () => {
+    const chart = scoreChordText(CHART);
+    expect(chart).toBeGreaterThan(0);
+    expect(chart).toBeGreaterThan(scoreChordText(BIO));
+    expect(chart).toBeGreaterThan(scoreChordText(NAV));
+  });
+  it('scores non-chart text at or near zero', () => {
+    expect(scoreChordText(BIO)).toBe(0);
+    expect(scoreChordText(NAV)).toBe(0);
+    expect(scoreChordText('')).toBe(0);
+  });
+});
+
+describe('pickBestCandidate', () => {
+  it('selects the chart among mixed candidates', () => {
+    const best = pickBestCandidate([
+      { tag: 'div', text: NAV },
+      { tag: 'pre', text: CHART },
+      { tag: 'div', text: BIO },
+    ]);
+    expect(best).not.toBeNull();
+    expect(best.text).toBe(CHART);
+  });
+
+  it('breaks ties toward the tighter (shorter) block', () => {
+    const wrapped = `Some header nav\n\n${CHART}\n\nfooter links here\nmore footer`;
+    const best = pickBestCandidate([
+      { tag: 'div', text: wrapped },
+      { tag: 'pre', text: CHART },
+    ]);
+    // Same chart content; the tighter <pre> should win on the tie-break path
+    // (or simply by higher density). Either way it must not pick the wrapper.
+    expect(best.text).toBe(CHART);
+  });
+
+  it('returns null when nothing looks like a chart', () => {
+    expect(pickBestCandidate([{ tag: 'div', text: BIO }])).toBeNull();
+  });
+});
+
+describe('parseTitleFromDocTitle', () => {
+  it('splits UG-style document titles into title/artist', () => {
+    expect(parseTitleFromDocTitle('Wonderwall Chords by Oasis @ Ultimate-Guitar.Com')).toEqual({
+      title: 'Wonderwall',
+      artist: 'Oasis',
+    });
+    expect(parseTitleFromDocTitle('Photograph Chords by Ed Sheeran | Ultimate Guitar')).toEqual({
+      title: 'Photograph',
+      artist: 'Ed Sheeran',
+    });
+  });
+  it('returns null on unrelated titles', () => {
+    expect(parseTitleFromDocTitle('Some random page title')).toBeNull();
+  });
+});

--- a/test/scraper-strategy.test.js
+++ b/test/scraper-strategy.test.js
@@ -1,0 +1,66 @@
+import { extractChordText } from '../src/scraper.js';
+
+// A strong chord-chart candidate (chords-above-lyrics with section headers).
+const CHART = `[Verse 1]
+G                 D
+White lips, pale face
+Em                C
+Breathing in the snowflakes
+
+[Chorus]
+Em   C   G   D
+Oh, oh, oh
+Em   C       G   D
+You're my everything`;
+
+// A low-content block that should not clear the score threshold.
+const LOW = `hello world
+just some text
+nothing musical
+plain prose here`;
+
+const SELECTOR_TEXT = 'SELECTOR-SOURCED CHART TEXT';
+
+// Minimal fake of a Puppeteer Page:
+//  - evaluate(fn): returns canned candidate blocks for the heuristic path.
+//  - $$eval(sel, fn): returns an array of strings (readJoined joins them).
+function makePage({ candidates = [], selectorParts = [SELECTOR_TEXT] }) {
+  return {
+    evaluate: async () => candidates,
+    $$eval: async () => selectorParts,
+  };
+}
+
+describe('extractChordText — strategy wiring', () => {
+  it('heuristic: returns the heuristic match (not the selector) for a strong chart', async () => {
+    const page = makePage({ candidates: [{ tag: 'pre', text: CHART }] });
+    const text = await extractChordText(page, 'heuristic', 5);
+    expect(text).toBe(CHART);
+  });
+
+  it('heuristic: falls back to the selector when nothing clears minScore', async () => {
+    // Best candidate exists but its score is below an impossibly-high threshold.
+    const page = makePage({ candidates: [{ tag: 'pre', text: CHART }] });
+    const text = await extractChordText(page, 'heuristic', 9999);
+    expect(text).toBe(SELECTOR_TEXT);
+  });
+
+  it('heuristic: falls back to the selector when the only candidate is low-content', async () => {
+    const page = makePage({ candidates: [{ tag: 'div', text: LOW }] });
+    const text = await extractChordText(page, 'heuristic', 5);
+    expect(text).toBe(SELECTOR_TEXT);
+  });
+
+  it('auto: returns the selector text without needing the heuristic', async () => {
+    // No candidates at all — proves the heuristic was not required.
+    const page = makePage({ candidates: [] });
+    const text = await extractChordText(page, 'auto', 5);
+    expect(text).toBe(SELECTOR_TEXT);
+  });
+
+  it('selector: returns selector text only (legacy behavior)', async () => {
+    const page = makePage({ candidates: [{ tag: 'pre', text: CHART }] });
+    const text = await extractChordText(page, 'selector', 5);
+    expect(text).toBe(SELECTOR_TEXT);
+  });
+});

--- a/test/scraper-strategy.test.js
+++ b/test/scraper-strategy.test.js
@@ -26,8 +26,8 @@ const SELECTOR_TEXT = 'SELECTOR-SOURCED CHART TEXT';
 //  - $$eval(sel, fn): returns an array of strings (readJoined joins them).
 function makePage({ candidates = [], selectorParts = [SELECTOR_TEXT] }) {
   return {
-    evaluate: async () => candidates,
-    $$eval: async () => selectorParts,
+    evaluate: () => Promise.resolve(candidates),
+    $$eval: () => Promise.resolve(selectorParts),
   };
 }
 


### PR DESCRIPTION
## What this does

Makes chord-chart extraction **content-based and resilient** to Ultimate Guitar's recurring DOM/class-name changes — the failure mode that breaks selector-based scraping. A new heuristic detector becomes the **primary** strategy; the exact CSS selector is demoted to a configurable fallback.

## Strategy (deliberate design)

`SCRAPE_STRATEGY` ∈ `{heuristic (default), auto, selector}`:
- **`heuristic`** — score candidate text blocks by content fingerprint; fall back to the selector if nothing clears `DETECT_MIN_SCORE`.
- **`auto`** — selector first (fast/unambiguous when it works); fall back to the heuristic.
- **`selector`** — selector only (exact legacy behavior).

Three things make heuristic-primary safe:
1. **Score threshold** (`DETECT_MIN_SCORE`, default 5) — a weak best-candidate is rejected → falls back to the selector rather than silently scraping the wrong element.
2. **Selector kept as fallback**, not deleted — still worth re-pinning when convenient.
3. **Env-switchable** — if the heuristic misbehaves live, flip `SCRAPE_STRATEGY` (no code change/redeploy of logic).

Title/artist also fall back to parsing `document.title` ("`<Song> Chords by <Artist>`") when their selectors fail, and `waitForSelector(ready)` is now best-effort so a rotted render-signal selector can't block the scrape.

## Changes

- **`src/detect.js`** (new) — pure, unit-tested scoring (`isChordToken`/`classifyLine`/`scoreChordText`/`pickBestCandidate`) + Puppeteer glue (`detectChordBlock`) + `parseTitleFromDocTitle`.
- **`src/scraper.js`** — `extractChordText(page, strategy, minScore)` implements the strategy; wired into `scrapeSong`; title/artist doc-title fallback.
- **`src/config.js`** — `SCRAPE_STRATEGY`, `DETECT_MIN_SCORE`.
- **Tests** — `test/detect.test.js` (11) and `test/scraper-strategy.test.js` (5, browser-free fake page).
- **Docs** — `.env.example`, `CLAUDE.md`, `README.md`.

## Verification

- `npm run lint` clean · `prettier --check` clean
- `npm test` → **20 passing** (11 detect + 5 strategy + 4 formatter)
- **Crown Jewels untouched:** `src/formatter.js`, `test/formatter.fixture.json`, and the formatter test have zero diff vs `main`; the 4 regression tests pass unchanged.
- Default behavior is heuristic-primary; `SCRAPE_STRATEGY=selector` restores exact legacy extraction.

## Human follow-up ⚠️

`collectCandidatesInPage` runs **in the browser** and is only exercised by a live scrape (it's excluded from coverage and marked for live integration). **Before trusting heuristic-primary in production, run one real scrape against a current UG URL** and confirm the `[detect]` log reports the expected element/score. If it ever misfires live, set `SCRAPE_STRATEGY=auto` (or `selector`) as an immediate mitigation while the selectors/threshold are re-pinned.

https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q)_