### PR TITLE
Add live-scrape validation harness (heuristic + selector re-pin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\"",
     "format": "prettier --write \"src/**/*.js\" \"test/**/*.js\"",
     "format:check": "prettier --check \"src/**/*.js\" \"test/**/*.js\"",
-    "fixture": "node scripts/capture-legacy-fixture.js"
+    "fixture": "node scripts/capture-legacy-fixture.js",
+    "validate": "node scripts/validate-scrape.js"
   },
   "keywords": [
     "ultimate-guitar",

--- a/scripts/validate-scrape.js
+++ b/scripts/validate-scrape.js
@@ -1,0 +1,119 @@
+// Live-scrape diagnostic harness. Given a real Ultimate Guitar URL, it launches
+// the production Puppeteer config and dumps everything needed to (a) confirm the
+// heuristic detector picks the chord block and (b) re-pin the CSS selectors in
+// src/config.js if they have rotted.
+//
+// Run: npm run validate -- "https://tabs.ultimate-guitar.com/tab/.../...-chords-..."
+//
+// This is a dev-only tool (scripts/ is excluded from analysis). The candidate
+// collector is duplicated inline so shipped src/detect.js stays untouched.
+
+import puppeteer from 'puppeteer';
+import { config, selectors } from '../src/config.js';
+import { scoreChordText, pickBestCandidate, parseTitleFromDocTitle } from '../src/detect.js';
+import { extractChordText } from '../src/scraper.js';
+
+const url = process.argv[2];
+if (!url) {
+  console.error('usage: npm run validate -- "<ultimate-guitar URL>"');
+  process.exit(1);
+}
+
+// Mirror of src/detect.js collectCandidatesInPage (runs in the browser).
+/* eslint-disable no-undef */
+function collectCandidatesInPage() {
+  const out = [];
+  const seen = new Set();
+  const consider = (el) => {
+    const text = el.innerText || el.textContent || '';
+    if (!text) return;
+    if (text.length > 20000) return;
+    if (text.split('\n').length < 4) return;
+    if (seen.has(text)) return;
+    seen.add(text);
+    out.push({ tag: el.tagName.toLowerCase(), text });
+  };
+  document.querySelectorAll('pre').forEach(consider);
+  document.querySelectorAll('div, section, article, td').forEach((el) => {
+    if (el.childElementCount <= 3) consider(el);
+  });
+  return out;
+}
+/* eslint-enable no-undef */
+
+const snippet = (s, n = 70) => JSON.stringify((s || '').replace(/\s+/g, ' ').trim().slice(0, n));
+
+async function main() {
+  const browser = await puppeteer.launch({
+    headless: config.puppeteer.headless,
+    args: config.puppeteer.args,
+    executablePath: config.puppeteer.executablePath,
+  });
+  try {
+    const page = await browser.newPage();
+    page.setDefaultNavigationTimeout(config.scrapeTimeoutMs);
+    page.setDefaultTimeout(config.scrapeTimeoutMs);
+    await page.setViewport({ width: 1350, height: 850 });
+
+    console.log(`\nNavigating to ${url} ...`);
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    await page
+      .waitForSelector(selectors.ready, { timeout: 8000 })
+      .then(() => console.log(`ready selector "${selectors.ready}" present ✓`))
+      .catch(() => console.log(`ready selector "${selectors.ready}" NOT found ✗`));
+
+    const docTitle = await page.title();
+    console.log('\n== document.title ==');
+    console.log(' ', JSON.stringify(docTitle));
+    console.log('  parseTitleFromDocTitle ->', parseTitleFromDocTitle(docTitle));
+
+    console.log('\n== configured selectors ==');
+    for (const [name, sel] of Object.entries(selectors)) {
+      const matches = await page
+        .$$eval(sel, (els) => els.map((e) => (e.textContent || '').trim()))
+        .catch(() => null);
+      if (matches === null) {
+        console.log(`  ${name} (${sel}): INVALID/ERROR`);
+      } else {
+        console.log(
+          `  ${name} (${sel}): ${matches.length} match(es)` +
+            (matches.length ? ` | ${snippet(matches.join(' | '))}` : '')
+        );
+      }
+    }
+
+    console.log('\n== heuristic candidates (top 5 by score) ==');
+    const candidates = await page.evaluate(collectCandidatesInPage);
+    const scored = candidates
+      .map((c) => ({ ...c, score: scoreChordText(c.text) }))
+      .sort((a, b) => b.score - a.score || a.text.length - b.text.length);
+    if (scored.length === 0) console.log('  (no candidates collected)');
+    for (const c of scored.slice(0, 5)) {
+      console.log(`  <${c.tag}> score=${c.score} len=${c.text.length} | ${snippet(c.text, 50)}`);
+    }
+    const best = pickBestCandidate(candidates);
+    console.log(
+      '\n  pickBestCandidate ->',
+      best
+        ? `<${best.tag}> score=${best.score} (minScore=${config.detectMinScore}) ` +
+            `${best.score >= config.detectMinScore ? 'PASS ✓' : 'BELOW THRESHOLD ✗'}`
+        : 'null'
+    );
+
+    console.log('\n== extractChordText by strategy ==');
+    for (const strategy of ['heuristic', 'auto', 'selector']) {
+      const text = await extractChordText(page, strategy, config.detectMinScore);
+      console.log(
+        `  ${strategy}: ${text.length} chars` + (text.length ? ` | ${snippet(text, 50)}` : ' (EMPTY)')
+      );
+    }
+    console.log('');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('validate-scrape failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this does (Part A of the deploy + mobile plan)

Adds `scripts/validate-scrape.js` — a dev-only diagnostic harness to **validate heuristic-primary extraction against a live Ultimate Guitar page** and surface the current DOM so the CSS selectors in `src/config.js` can be re-pinned if they've rotted (they've been unverified since 2024).

`npm run validate -- "<UG URL>"` launches the production Puppeteer config and prints:
- `document.title` + what `parseTitleFromDocTitle` extracts
- each configured selector's match count + snippet (a rotted selector shows as **0 matches**)
- the top-5 heuristic candidates by score, and `pickBestCandidate`'s verdict vs `DETECT_MIN_SCORE`
- `extractChordText` output length for `heuristic` / `auto` / `selector`

It reuses `src/detect.js` and `src/scraper.js` exports, so **no shipped code changes** (the candidate collector is duplicated inline; `scripts/` is excluded from analysis).

## Verification

- Self-tested against a local UG-shaped fixture: heuristic picks the `<pre>` (score 27 ≥ minScore 5), title/artist parse from `document.title`, all three strategies return the chart. `npm test` still 20/20.
- **Pending:** the real live run needs a current UG chord-chart URL (the user is providing one). Note UG `403`s this sandbox's IP for non-browser requests, so if anti-bot also blocks headless Chrome here, the same harness should be run from the user's machine or the deployed Cloud Run service.

## Follow-up
If the live run shows a stale selector, a one-line re-pin of `selectors` in `src/config.js` will follow in this PR.

https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q)_