### PR TITLE
Docs: iOS Shortcut to trigger a scrape from the phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,19 @@ Two **human action items** that cannot be automated:
 2. Add the deployed `/oauth2callback` URL to the OAuth client's Authorized redirect URIs.
 3. (Maintenance) Re-pin the UG selectors in `src/config.js` if a scrape returns empty fields.
 
+CI/CD: PRs are gated by `.github/workflows/ci.yml` and merges to `main` auto-deploy to Cloud Run via
+`.github/workflows/deploy.yml` (keyless Workload Identity Federation) — see `DEPLOY.md` §7.
+
+## Trigger from your phone
+
+`POST /scrape` is all a phone needs. See **[docs/MOBILE.md](./docs/MOBILE.md)** for an **iOS Shortcut**
+that takes a shared Ultimate Guitar link from the Share Sheet, calls the service with the `x-api-key`,
+and opens the finished Google Doc.
+
 ## Out of scope (deferred)
 
-PDF auto-export, repeating-chord-pattern dedup, and the mobile trigger surface (PWA / Telegram bot /
-iOS Shortcut). Clean extension points are left in place.
+PDF auto-export, repeating-chord-pattern dedup, and other mobile surfaces (web PWA / Telegram bot).
+Clean extension points are left in place.
 
 ## Conventions
 

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1,0 +1,80 @@
+# Trigger a scrape from your phone (iOS Shortcut)
+
+songscraper needs no app and no new code to be driven from a phone. `POST /scrape { url }` already
+returns `{ docUrl, title, artist }`, so an **iOS Shortcut** can take a shared Ultimate Guitar link,
+call the service, and open the finished Google Doc.
+
+## Prerequisites
+
+- The service deployed and reachable at a public HTTPS URL (Cloud Run). For the Shortcut to call it
+  without a Google identity token, deploy with `--allow-unauthenticated` — the service stays protected
+  by the `x-api-key` shared secret + UG-URL validation (see `DEPLOY.md` §7). The API key **is** the
+  auth boundary.
+- Your `API_KEY` value (the same secret the service checks). Treat it like a password.
+
+## Build the Shortcut
+
+Open **Shortcuts → + (new) → rename it e.g. "Scrape Song"**, then add these actions in order:
+
+1. **Settings (ⓘ at the bottom): turn on "Show in Share Sheet"**, and set *Share Sheet Types* to
+   **URLs** (and optionally *Text*). This makes the Shortcut appear when you tap **Share** on a tab in
+   Safari or the Ultimate Guitar app.
+
+2. **Receive** `URLs` input from **Share Sheet**. Set *If there's no input*: **Ask for Input** (Type:
+   URL) — so you can also run it manually and paste a link.
+
+3. **Text** → set its value to the Shortcut Input (the shared URL). (This gives a clean string to put
+   in the request body.)
+
+4. **Get Contents of URL**:
+   - **URL**: `https://<your-cloud-run-url>/scrape`
+   - **Method**: `POST`
+   - **Headers**:
+     - `x-api-key` = `<YOUR_API_KEY>`
+     - `Content-Type` = `application/json`
+   - **Request Body**: **JSON**
+     - key `url` (Text) = the **Text** variable from step 3
+
+5. **Get Dictionary Value** → **Value** for key `docUrl` from the **Contents of URL** result.
+
+6. **Open URLs** → the `docUrl` value. (Opens the new Google Doc in Safari/Docs.)
+   - Optional: add **Show Notification** with the `title` and `artist` dictionary values for a
+     confirmation toast instead of (or before) opening.
+
+## Use it
+
+- From Safari or the UG app, open a chord chart → **Share** → **Scrape Song** → the Doc opens.
+- Or run the Shortcut from the Home Screen / "Hey Siri, Scrape Song" and paste a link.
+
+## Request shape (reference)
+
+```http
+POST /scrape
+Host: <your-cloud-run-url>
+x-api-key: <YOUR_API_KEY>
+Content-Type: application/json
+
+{ "url": "https://tabs.ultimate-guitar.com/tab/.../...-chords-..." }
+```
+
+```json
+// 200 OK
+{ "docUrl": "https://docs.google.com/document/d/.../edit", "title": "...", "artist": "..." }
+```
+
+Errors: `401` (missing/invalid `x-api-key`), `400` (not a valid `ultimate-guitar.com` URL), `500`
+(scrape or Google API failure — body has a `detail`).
+
+## Security notes
+
+- The `x-api-key` stored in the Shortcut grants scrape access. If a device is lost or the key leaks,
+  rotate it: add a new `API_KEY` secret version and redeploy, then update the Shortcut.
+- Keep the URL validation and the constant-time key check (already in `src/server.js`) — never expose
+  `/scrape` without the key.
+
+## Android / other phones
+
+The same HTTP contract works from any client. Android equivalents: an **HTTP Shortcuts** app, a
+**Tasker** task, or — for a no-install, cross-platform option — a small **Telegram bot** that forwards
+a pasted link to `/scrape` and replies with the Doc link. (Telegram bot is out of scope here; the
+iOS Shortcut is the chosen path.)


### PR DESCRIPTION
## What this does (Part C of the deploy + mobile plan)

Documents an **iOS Shortcut** that triggers a scrape from the phone's Share Sheet — the chosen mobile path.

`POST /scrape { url }` already returns `{ docUrl, title, artist }`, so **no backend changes are needed**. `docs/MOBILE.md` gives the step-by-step Shortcut recipe:
- Show in Share Sheet (URLs) → appears when you Share a tab from Safari / the UG app
- `Get Contents of URL` → `POST /scrape` with `x-api-key` + `{ "url": <shared link> }`
- `Get Dictionary Value` `docUrl` → `Open URLs` (opens the Google Doc); optional notification with title/artist

Also documents the request/response contract, the `--allow-unauthenticated` + API-key auth model (the key is the boundary), key rotation, and Android alternatives (HTTP Shortcuts / Tasker / Telegram bot).

`README.md`: adds a "Trigger from your phone" pointer + a CI/CD note, and removes the iOS Shortcut from the deferred list.

## Notes
- The `--allow-unauthenticated` + API-key auth model is set up by the deploy workflow in PR #10; this PR documents the phone-side usage. Independent of #10 (touches only `docs/MOBILE.md` + `README.md`), so no merge conflict.

## Verification
Build the Shortcut from `docs/MOBILE.md`, share a UG link → confirm it POSTs, receives `docUrl`, and opens the Doc; a missing/wrong `x-api-key` returns `401`.

https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLsxMv44X8d2EF2Ez9yJ4Q)_