### PR TITLE
feat(fetcher): env-switchable FETCH_STRATEGY (direct/proxy/unlocker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,24 @@ DRIVE_FOLDER_ID=
 SCRAPE_STRATEGY=heuristic
 # Minimum score the heuristic must clear before it's trusted (tune if needed).
 DETECT_MIN_SCORE=5
+
+# ── Fetch strategy (anti-bot) ─────────────────────────────────────────────────
+# How the page is FETCHED (orthogonal to SCRAPE_STRATEGY, which is how the chart
+# text is then located in the page). Ultimate Guitar is behind Cloudflare bot
+# protection that blocks headless Chrome from ANY IP — so the deployed service
+# needs proxy/unlocker even though `direct` is fine for local dev.
+#   direct (default) — Puppeteer navigates UG directly
+#   proxy            — Puppeteer navigates through a residential/mobile proxy
+#   unlocker         — a web-unlocker/scraping API returns rendered HTML
+FETCH_STRATEGY=direct
+
+# For FETCH_STRATEGY=proxy — a residential/mobile proxy (datacenter IPs are blocked).
+# PROXY_SERVER=http://gateway.provider.com:7000
+# PROXY_USERNAME=
+# PROXY_PASSWORD=
+
+# For FETCH_STRATEGY=unlocker — a web-unlocker API (Bright Data, Scrapfly, Zyte,
+# ScrapingBee, …). The request shape varies by provider; adapt fetchViaUnlocker
+# in src/fetcher.js. Treat the key as a secret (Secret Manager in prod).
+# UNLOCKER_API_URL=https://api.provider.com/unlock
+# UNLOCKER_API_KEY=

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -100,6 +100,19 @@ Now:
 > (b) run the bootstrap **locally** (see "Local bootstrap" below) and only deploy the resulting token.
 > Either way, `/scrape` stays protected by the API key on top of any IAM.
 
+> **⚠️ Anti-bot — `FETCH_STRATEGY` is required on Cloud Run.** Ultimate Guitar is behind Cloudflare
+> bot protection that blocks headless Chrome from any IP, so the default `FETCH_STRATEGY=direct` will
+> return a "Just a moment…" challenge and the scrape will fail with a clear error. Set a real-user
+> egress on the deployed service (see README → *Fetching past Cloudflare*). Recommended — a web
+> unlocker API:
+> ```bash
+> gcloud run services update songscraper --region="$REGION" \
+>   --update-env-vars="FETCH_STRATEGY=unlocker,UNLOCKER_API_URL=https://api.provider.com/unlock" \
+>   --update-secrets="UNLOCKER_API_KEY=UNLOCKER_API_KEY:latest"
+> ```
+> (Create the `UNLOCKER_API_KEY` secret first, as in step 3. For `FETCH_STRATEGY=proxy` instead, set
+> `PROXY_SERVER` and the `PROXY_USERNAME`/`PROXY_PASSWORD` secret.)
+
 ---
 
 ## 5. One-time OAuth bootstrap (mint the refresh token)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ misbehaves in production (flip the env var, no code change):
 trusted — a weak best-candidate is rejected rather than scraping the wrong element. Title/artist also
 fall back to parsing `document.title` when their selectors fail.
 
+## Fetching past Cloudflare (`FETCH_STRATEGY`)
+
+`SCRAPE_STRATEGY` decides how the chart text is **located** in a page; `FETCH_STRATEGY` decides how
+the page is **fetched**. They are orthogonal. Ultimate Guitar sits behind Cloudflare bot protection
+that serves a "Just a moment…" challenge to headless Chrome from **any** IP — datacenter *and*
+residential (confirmed against a clean residential connection). A headed browser passes, but Cloud
+Run has no display, so the deployed service needs a real-user egress:
+
+| `FETCH_STRATEGY` | Behavior | Use |
+|---|---|---|
+| `direct` (default) | Puppeteer navigates UG directly | local dev only — blocked on Cloud Run |
+| `proxy` | Puppeteer navigates through a residential/mobile proxy, then waits out the interstitial | cheaper, more tuning; set `PROXY_SERVER`/`PROXY_USERNAME`/`PROXY_PASSWORD` |
+| `unlocker` | a web-unlocker API returns rendered HTML (solves Cloudflare + TLS fingerprint + proxies) loaded via `setContent` | **recommended** for Cloud Run; set `UNLOCKER_API_URL`/`UNLOCKER_API_KEY` |
+
+The fetch layer lives in `src/fetcher.js` and funnels every strategy down to a single Puppeteer
+`page`, so extraction/formatting is reused unchanged. The unlocker request shape varies by provider
+(Bright Data, Scrapfly, Zyte, ScrapingBee, …) — `fetchViaUnlocker` is the one function to adapt. On
+the `direct`/`proxy` paths a clear, actionable error is thrown if a challenge page is detected.
+
 ## Endpoints
 
 | Method | Route | Auth | Purpose |

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,12 @@ const {
   PUPPETEER_EXECUTABLE_PATH,
   SCRAPE_STRATEGY,
   DETECT_MIN_SCORE,
+  FETCH_STRATEGY,
+  PROXY_SERVER,
+  PROXY_USERNAME,
+  PROXY_PASSWORD,
+  UNLOCKER_API_URL,
+  UNLOCKER_API_KEY,
 } = process.env;
 
 export const config = {
@@ -54,6 +60,32 @@ export const config = {
   scrapeStrategy: SCRAPE_STRATEGY || 'heuristic',
   // Minimum chord-chart score the heuristic must clear to be trusted.
   detectMinScore: Number(DETECT_MIN_SCORE) || 5,
+
+  // How the chart page is *fetched* (orthogonal to how the chart text is then
+  // extracted, which is scrapeStrategy above):
+  //   direct (default) — Puppeteer navigates UG itself (today's behavior).
+  //   proxy            — Puppeteer navigates through a residential/mobile proxy.
+  //   unlocker         — a scraping/"web unlocker" API returns rendered HTML,
+  //                      which we load into the page (it solves Cloudflare + TLS
+  //                      fingerprint + proxies internally).
+  // Default is `direct` so local dev is unchanged. UG sits behind Cloudflare bot
+  // protection that blocks headless Chrome from any IP (datacenter *and*
+  // residential), so the deployed service on Cloud Run needs `proxy`/`unlocker`.
+  fetchStrategy: FETCH_STRATEGY || 'direct',
+  // Residential/mobile proxy for FETCH_STRATEGY=proxy. `server` is the launch
+  // arg value, e.g. "http://gw.example.com:7000". Creds are sent via page auth.
+  proxy: {
+    server: PROXY_SERVER || '',
+    username: PROXY_USERNAME || '',
+    password: PROXY_PASSWORD || '',
+  },
+  // Web-unlocker / scraping API for FETCH_STRATEGY=unlocker. The exact request
+  // shape varies by provider — see src/fetcher.js (fetchViaUnlocker) for the one
+  // integration point to adapt.
+  unlocker: {
+    apiUrl: UNLOCKER_API_URL || '',
+    apiKey: UNLOCKER_API_KEY || '',
+  },
 };
 
 // Ultimate Guitar DOM selectors. These rot whenever UG ships a markup change.

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,0 +1,145 @@
+// Page acquisition, decoupled from extraction. Ultimate Guitar sits behind
+// Cloudflare bot protection that serves an interstitial ("Just a moment…") to
+// headless Chrome from *any* IP — datacenter and residential alike — so the
+// deployed service cannot simply navigate to the URL. `loadChartPage` funnels
+// every fetch strategy down to a single Puppeteer `page` so the rest of the
+// pipeline (extractChordText / detect.js / selectors / formatter) is reused
+// unchanged regardless of how the HTML was obtained.
+//
+// Strategies (config.fetchStrategy):
+//   direct   — navigate UG directly (today's behavior; the local-dev default).
+//   proxy    — navigate through a residential/mobile proxy, then wait out the
+//              Cloudflare interstitial if one appears.
+//   unlocker — fetch rendered HTML from a web-unlocker API and load it into the
+//              page via setContent (the API handles Cloudflare/TLS/proxy itself).
+
+import { config, selectors } from './config.js';
+
+// Markers of a Cloudflare (or similar) bot-check interstitial, matched against
+// the page title and/or a snippet of the HTML. Kept deliberately broad.
+const CHALLENGE_MARKERS = [
+  /just a moment/i,
+  /attention required/i,
+  /checking your browser/i,
+  /verify(?:ing)? you are human/i,
+  /cf-browser-verification/i,
+  /enable javascript and cookies to continue/i,
+];
+
+/**
+ * Whether a page title (or HTML snippet) looks like an anti-bot challenge rather
+ * than the real chart page.
+ * @param {string} text - the document title and/or page HTML
+ * @returns {boolean}
+ */
+export function isChallengePage(text) {
+  if (!text) return false;
+  return CHALLENGE_MARKERS.some((re) => re.test(text));
+}
+
+/**
+ * Extra Chrome launch args for a fetch strategy. Only `proxy` needs any: the
+ * proxy server must be set at browser launch (credentials are supplied per-page
+ * via page.authenticate). `direct`/`unlocker` add nothing.
+ * @param {string} [strategy=config.fetchStrategy]
+ * @returns {string[]}
+ */
+export function launchArgs(strategy = config.fetchStrategy) {
+  if (strategy === 'proxy' && config.proxy.server) {
+    return [`--proxy-server=${config.proxy.server}`];
+  }
+  return [];
+}
+
+/**
+ * Fetch fully-rendered HTML for `url` from the configured web-unlocker API.
+ *
+ * THIS IS THE PER-PROVIDER INTEGRATION POINT. Providers differ (Bright Data,
+ * Scrapfly, Zyte, ScrapingBee…); this sends a generic POST `{ url, render: true }`
+ * with a Bearer key and accepts either a raw-HTML body or a JSON envelope with
+ * the HTML under `content`/`html`/`body`/`data`. Adapt to your provider's API.
+ * @param {string} url - the target Ultimate Guitar URL
+ * @returns {Promise<string>} rendered HTML
+ */
+export async function fetchViaUnlocker(url) {
+  const { apiUrl, apiKey } = config.unlocker;
+  if (!apiUrl) {
+    throw new Error('FETCH_STRATEGY=unlocker but UNLOCKER_API_URL is not set.');
+  }
+  const res = await fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify({ url, render: true }),
+  });
+  if (!res.ok) {
+    throw new Error(`Unlocker request failed: ${res.status} ${res.statusText}`);
+  }
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    const data = await res.json();
+    const html = data.content ?? data.html ?? data.body ?? data.data;
+    if (!html) {
+      throw new Error('Unlocker JSON response contained no HTML (expected content/html/body/data).');
+    }
+    return html;
+  }
+  return res.text();
+}
+
+/**
+ * Wait (bounded, condition-based — no timers) for a Cloudflare interstitial to
+ * resolve to the real page. Resolves as soon as the title no longer matches a
+ * challenge marker; gives up quietly on timeout so the caller's challenge guard
+ * can surface a clear error.
+ * @param {import('puppeteer').Page} page
+ * @returns {Promise<void>}
+ */
+async function waitForChallengeToClear(page) {
+  await page
+    .waitForFunction(
+      (markers) => !markers.some((re) => new RegExp(re.source, re.flags).test(document.title)),
+      { timeout: config.scrapeTimeoutMs },
+      CHALLENGE_MARKERS.map((re) => ({ source: re.source, flags: re.flags }))
+    )
+    .catch(() => null);
+}
+
+/**
+ * Open `url` and return a Puppeteer page holding the chart's DOM, using the
+ * configured fetch strategy. The browser is owned by the caller (scrapeSong),
+ * which closes it deterministically; this only creates and loads the page.
+ * @param {import('puppeteer').Browser} browser
+ * @param {string} url - a validated ultimate-guitar.com chart URL
+ * @param {string} [strategy=config.fetchStrategy]
+ * @returns {Promise<import('puppeteer').Page>}
+ */
+export async function loadChartPage(browser, url, strategy = config.fetchStrategy) {
+  const page = await browser.newPage();
+  page.setDefaultNavigationTimeout(config.scrapeTimeoutMs);
+  page.setDefaultTimeout(config.scrapeTimeoutMs);
+  await page.setViewport({ width: 1350, height: 850 });
+
+  if (strategy === 'unlocker') {
+    const html = await fetchViaUnlocker(url);
+    await page.setContent(html, { waitUntil: 'domcontentloaded' });
+    return page;
+  }
+
+  if (strategy === 'proxy' && config.proxy.username) {
+    await page.authenticate({
+      username: config.proxy.username,
+      password: config.proxy.password,
+    });
+  }
+
+  await page.goto(url, { waitUntil: 'networkidle2' });
+  if (strategy === 'proxy') {
+    await waitForChallengeToClear(page);
+  }
+  // Best-effort: wait on the known render signal, but don't fail if it has rotted.
+  await page.waitForSelector(selectors.ready).catch(() => null);
+  return page;
+}

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -5,6 +5,7 @@
 import puppeteer from 'puppeteer';
 import { config, selectors } from './config.js';
 import { detectChordBlock, parseTitleFromDocTitle } from './detect.js';
+import { loadChartPage, launchArgs, isChallengePage } from './fetcher.js';
 
 /**
  * Read every match of `selector` and return the concatenated textContent.
@@ -64,18 +65,24 @@ export async function scrapeSong(url) {
   try {
     browser = await puppeteer.launch({
       headless: config.puppeteer.headless,
-      args: config.puppeteer.args,
+      args: [...config.puppeteer.args, ...launchArgs()],
       executablePath: config.puppeteer.executablePath,
     });
 
-    const page = await browser.newPage();
-    page.setDefaultNavigationTimeout(config.scrapeTimeoutMs);
-    page.setDefaultTimeout(config.scrapeTimeoutMs);
-    await page.setViewport({ width: 1350, height: 850 });
+    // Acquire the chart page via the configured fetch strategy (direct/proxy/
+    // unlocker). loadChartPage handles navigation, proxy auth, and the ready wait.
+    const page = await loadChartPage(browser, url);
 
-    await page.goto(url, { waitUntil: 'networkidle2' });
-    // Best-effort: wait on the known render signal, but don't fail if it has rotted.
-    await page.waitForSelector(selectors.ready).catch(() => null);
+    // Fail fast with a clear, actionable message if we got an anti-bot wall
+    // instead of the chart (the unlocker path is expected to have solved it).
+    if (config.fetchStrategy !== 'unlocker' && isChallengePage(await page.title())) {
+      throw new Error(
+        'Blocked by anti-bot protection (a Cloudflare-style challenge page was returned ' +
+          `instead of the chart). FETCH_STRATEGY is "${config.fetchStrategy}". UG blocks ` +
+          'headless Chrome from any IP; set FETCH_STRATEGY=unlocker (recommended) or =proxy ' +
+          'with a residential/mobile proxy. See README.md / DEPLOY.md.'
+      );
+    }
 
     const rawText = await extractChordText(page);
     const rawTitle = await readFirst(page, selectors.title);

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -3,27 +3,32 @@ import { isChallengePage, launchArgs, fetchViaUnlocker, loadChartPage } from '..
 
 const CHART_HTML = '<html><head><title>Open Shut Them Chords</title></head><body><pre>[Intro]</pre></body></html>';
 
-// A fake Puppeteer page that records calls without a real browser.
+// A fake Puppeteer page that records calls without a real browser. Methods are
+// plain (non-async) — the code under test awaits them, and `await` on a
+// non-promise is a no-op, so this keeps the mock simple and lint-clean.
 function makeFakePage({ title = 'Open Shut Them Chords' } = {}) {
   const calls = { setContent: [], goto: [], authenticate: [], waitForSelector: 0, waitForFunction: 0 };
   return {
     _calls: calls,
-    setDefaultNavigationTimeout: () => {},
-    setDefaultTimeout: () => {},
-    setViewport: async () => {},
-    setContent: async (html, opts) => calls.setContent.push([html, opts]),
-    goto: async (url, opts) => calls.goto.push([url, opts]),
-    authenticate: async (creds) => calls.authenticate.push(creds),
-    waitForSelector: async () => {
+    setDefaultNavigationTimeout: () => undefined,
+    setDefaultTimeout: () => undefined,
+    setViewport: () => undefined,
+    setContent: (html, opts) => calls.setContent.push([html, opts]),
+    goto: (url, opts) => calls.goto.push([url, opts]),
+    authenticate: (creds) => calls.authenticate.push(creds),
+    // These are awaited with a `.catch(...)` in fetcher.js, so return a thenable.
+    waitForSelector: () => {
       calls.waitForSelector += 1;
+      return Promise.resolve();
     },
-    waitForFunction: async () => {
+    waitForFunction: () => {
       calls.waitForFunction += 1;
+      return Promise.resolve();
     },
-    title: async () => title,
+    title: () => title,
   };
 }
-const makeFakeBrowser = (page) => ({ newPage: async () => page });
+const makeFakeBrowser = (page) => ({ newPage: () => page });
 
 // A minimal fetch Response stand-in.
 const fakeResponse = ({ ok = true, status = 200, statusText = 'OK', contentType = 'application/json', body } = {}) => ({
@@ -31,8 +36,8 @@ const fakeResponse = ({ ok = true, status = 200, statusText = 'OK', contentType 
   status,
   statusText,
   headers: { get: (k) => (k.toLowerCase() === 'content-type' ? contentType : null) },
-  json: async () => body,
-  text: async () => body,
+  json: () => body,
+  text: () => body,
 });
 
 describe('isChallengePage', () => {
@@ -83,7 +88,7 @@ describe('fetchViaUnlocker', () => {
 
 describe('unlocker path (env-configured)', () => {
   const OLD_ENV = process.env;
-  let mod;
+  let mod = null;
 
   beforeEach(async () => {
     jest.resetModules();

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -109,22 +109,22 @@ describe('unlocker path (env-configured)', () => {
   });
 
   it('fetchViaUnlocker returns HTML from a JSON envelope', async () => {
-    globalThis.fetch = async () => fakeResponse({ contentType: 'application/json', body: { content: CHART_HTML } });
+    globalThis.fetch = () => fakeResponse({ contentType: 'application/json', body: { content: CHART_HTML } });
     expect(await mod.fetchViaUnlocker('https://ug/x')).toBe(CHART_HTML);
   });
 
   it('fetchViaUnlocker returns a raw-HTML body', async () => {
-    globalThis.fetch = async () => fakeResponse({ contentType: 'text/html', body: CHART_HTML });
+    globalThis.fetch = () => fakeResponse({ contentType: 'text/html', body: CHART_HTML });
     expect(await mod.fetchViaUnlocker('https://ug/x')).toBe(CHART_HTML);
   });
 
   it('fetchViaUnlocker throws on a non-OK response', async () => {
-    globalThis.fetch = async () => fakeResponse({ ok: false, status: 429, statusText: 'Too Many Requests' });
+    globalThis.fetch = () => fakeResponse({ ok: false, status: 429, statusText: 'Too Many Requests' });
     await expect(mod.fetchViaUnlocker('https://ug/x')).rejects.toThrow(/429/);
   });
 
   it('loadChartPage(unlocker) loads the fetched HTML via setContent, not goto', async () => {
-    globalThis.fetch = async () => fakeResponse({ contentType: 'application/json', body: { html: CHART_HTML } });
+    globalThis.fetch = () => fakeResponse({ contentType: 'application/json', body: { html: CHART_HTML } });
     const page = makeFakePage();
     await mod.loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'unlocker');
     expect(page._calls.setContent).toHaveLength(1);

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -1,0 +1,139 @@
+import { jest } from '@jest/globals';
+import { isChallengePage, launchArgs, fetchViaUnlocker, loadChartPage } from '../src/fetcher.js';
+
+const CHART_HTML = '<html><head><title>Open Shut Them Chords</title></head><body><pre>[Intro]</pre></body></html>';
+
+// A fake Puppeteer page that records calls without a real browser.
+function makeFakePage({ title = 'Open Shut Them Chords' } = {}) {
+  const calls = { setContent: [], goto: [], authenticate: [], waitForSelector: 0, waitForFunction: 0 };
+  return {
+    _calls: calls,
+    setDefaultNavigationTimeout: () => {},
+    setDefaultTimeout: () => {},
+    setViewport: async () => {},
+    setContent: async (html, opts) => calls.setContent.push([html, opts]),
+    goto: async (url, opts) => calls.goto.push([url, opts]),
+    authenticate: async (creds) => calls.authenticate.push(creds),
+    waitForSelector: async () => {
+      calls.waitForSelector += 1;
+    },
+    waitForFunction: async () => {
+      calls.waitForFunction += 1;
+    },
+    title: async () => title,
+  };
+}
+const makeFakeBrowser = (page) => ({ newPage: async () => page });
+
+// A minimal fetch Response stand-in.
+const fakeResponse = ({ ok = true, status = 200, statusText = 'OK', contentType = 'application/json', body } = {}) => ({
+  ok,
+  status,
+  statusText,
+  headers: { get: (k) => (k.toLowerCase() === 'content-type' ? contentType : null) },
+  json: async () => body,
+  text: async () => body,
+});
+
+describe('isChallengePage', () => {
+  it('flags Cloudflare-style interstitials', () => {
+    for (const t of ['Just a moment...', 'Attention Required! | Cloudflare', 'Checking your browser']) {
+      expect(isChallengePage(t)).toBe(true);
+    }
+  });
+  it('passes a real chart title and empty input', () => {
+    expect(isChallengePage('Open Shut Them Chords by Misc Children')).toBe(false);
+    expect(isChallengePage('')).toBe(false);
+  });
+});
+
+describe('launchArgs', () => {
+  it('adds nothing for direct/unlocker', () => {
+    expect(launchArgs('direct')).toEqual([]);
+    expect(launchArgs('unlocker')).toEqual([]);
+  });
+  it('adds nothing for proxy when no PROXY_SERVER is configured (off by default)', () => {
+    expect(launchArgs('proxy')).toEqual([]);
+  });
+});
+
+describe('loadChartPage — strategy wiring (no env)', () => {
+  it('direct: navigates to the URL and never uses setContent', async () => {
+    const page = makeFakePage();
+    await loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'direct');
+    expect(page._calls.goto).toHaveLength(1);
+    expect(page._calls.goto[0][0]).toBe('https://ug/x');
+    expect(page._calls.setContent).toHaveLength(0);
+    expect(page._calls.waitForSelector).toBe(1);
+  });
+
+  it('proxy: navigates and waits out the challenge interstitial', async () => {
+    const page = makeFakePage();
+    await loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'proxy');
+    expect(page._calls.goto).toHaveLength(1);
+    expect(page._calls.waitForFunction).toBe(1); // the challenge-clear wait
+  });
+});
+
+describe('fetchViaUnlocker', () => {
+  it('throws a clear error when UNLOCKER_API_URL is unset', async () => {
+    await expect(fetchViaUnlocker('https://ug/x')).rejects.toThrow(/UNLOCKER_API_URL is not set/);
+  });
+});
+
+describe('unlocker path (env-configured)', () => {
+  const OLD_ENV = process.env;
+  let mod;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      FETCH_STRATEGY: 'unlocker',
+      UNLOCKER_API_URL: 'https://unlock.example/api',
+      UNLOCKER_API_KEY: 'secret',
+      PROXY_SERVER: 'http://gw.example:7000',
+      PROXY_USERNAME: 'user',
+      PROXY_PASSWORD: 'pass',
+    };
+    mod = await import('../src/fetcher.js');
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    delete globalThis.fetch;
+  });
+
+  it('fetchViaUnlocker returns HTML from a JSON envelope', async () => {
+    globalThis.fetch = async () => fakeResponse({ contentType: 'application/json', body: { content: CHART_HTML } });
+    expect(await mod.fetchViaUnlocker('https://ug/x')).toBe(CHART_HTML);
+  });
+
+  it('fetchViaUnlocker returns a raw-HTML body', async () => {
+    globalThis.fetch = async () => fakeResponse({ contentType: 'text/html', body: CHART_HTML });
+    expect(await mod.fetchViaUnlocker('https://ug/x')).toBe(CHART_HTML);
+  });
+
+  it('fetchViaUnlocker throws on a non-OK response', async () => {
+    globalThis.fetch = async () => fakeResponse({ ok: false, status: 429, statusText: 'Too Many Requests' });
+    await expect(mod.fetchViaUnlocker('https://ug/x')).rejects.toThrow(/429/);
+  });
+
+  it('loadChartPage(unlocker) loads the fetched HTML via setContent, not goto', async () => {
+    globalThis.fetch = async () => fakeResponse({ contentType: 'application/json', body: { html: CHART_HTML } });
+    const page = makeFakePage();
+    await mod.loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'unlocker');
+    expect(page._calls.setContent).toHaveLength(1);
+    expect(page._calls.setContent[0][0]).toBe(CHART_HTML);
+    expect(page._calls.goto).toHaveLength(0);
+  });
+
+  it('launchArgs(proxy) includes the proxy server when configured', () => {
+    expect(mod.launchArgs('proxy')).toEqual(['--proxy-server=http://gw.example:7000']);
+  });
+
+  it('loadChartPage(proxy) authenticates when credentials are set', async () => {
+    const page = makeFakePage();
+    await mod.loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'proxy');
+    expect(page._calls.authenticate).toEqual([{ username: 'user', password: 'pass' }]);
+  });
+});


### PR DESCRIPTION
## Why

Live testing proved Ultimate Guitar's Cloudflare bot protection serves a `"Just a moment…"` challenge to **headless Chrome from any IP** — including a clean **residential** M3 connection, not just datacenter IPs. A **headed** browser passes the same URL, which isolates the trigger to the headless fingerprint. Cloud Run has no display, so the deployed service needs a real-user egress.

## What

A **fetch layer** (`src/fetcher.js`) that is orthogonal to the existing extraction strategy (`SCRAPE_STRATEGY`). Every strategy funnels down to one Puppeteer `page`, so `extractChordText` / `detect.js` / selectors / formatter are **reused unchanged**.

| `FETCH_STRATEGY` | Behavior | Use |
|---|---|---|
| `direct` (default) | navigate UG directly | local dev — blocked on Cloud Run |
| `proxy` | navigate through a residential/mobile proxy, then wait out the interstitial (condition-based `waitForFunction`, no timers) | cheaper, more tuning |
| `unlocker` | fetch rendered HTML from a web-unlocker API, load via `setContent` | **recommended** for Cloud Run |

- `scrapeSong` acquires the page via `loadChartPage` and throws a **clear, actionable error** if a challenge page is returned on the direct/proxy path.
- `fetchViaUnlocker` is the single per-provider integration point (Bright Data / Scrapfly / Zyte / ScrapingBee differ in request shape).
- **Default `direct` ⇒ local dev unchanged.** All new config is off unless set.

## Config
`FETCH_STRATEGY` + `PROXY_SERVER`/`PROXY_USERNAME`/`PROXY_PASSWORD` + `UNLOCKER_API_URL`/`UNLOCKER_API_KEY`.

## Tests
`test/fetcher.test.js` (browser-free): challenge detection, strategy wiring (direct/proxy/unlocker), launch args, unlocker fetch (JSON envelope · raw HTML · non-OK · missing-URL). **33/33 pass · lint clean** · `fetcher.js` ~92% line coverage.

> Note: overall coverage is held down by `scrapeSong`/`assertConfig` being browser/integration paths that predate unit tests — not changed by this PR.

## Docs
README *Fetching past Cloudflare*, `.env.example`, DEPLOY.md (Cloud Run must set `FETCH_STRATEGY`).

## Merge order
Independent of [#12](https://github.com/konjoinfinity/songscraper/pull/12) (heuristic fix), but both touch `config.js`/`scraper.js` — whichever lands second may need a trivial rebase.

## Crown Jewels
Formatter untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)