### PR TITLE
feat: free self-hosted scraping on a Raspberry Pi (headed browser, direct)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,15 @@ TEMPLATE_DOC_ID=1xM26IwbTj7L9VNXwDLyXV4ZWSdLUvRybDclq_u46My4
 DRIVE_FOLDER_ID=
 
 # Puppeteer: in the container we use the bundled Chromium. To point at a system
-# Chrome instead, set this to its absolute path.
-# PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+# Chrome instead, set this to its absolute path (required on a Raspberry Pi, which
+# has no bundled ARM Chrome — install `chromium` via apt and point here).
+# PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Headless by default. Set to `false` to launch a REAL (headed) browser — the
+# sanctioned self-hosted path: on your own residential hardware (e.g. a Raspberry
+# Pi run under `xvfb-run`), where UG's Cloudflare wall lets a real browser on a
+# residential IP through. Only the literal `false` flips it. See docs/RASPBERRY_PI.md.
+# PUPPETEER_HEADLESS=false
 
 # ── Scraping strategy ─────────────────────────────────────────────────────────
 # How the chord chart is located on the page:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,17 @@ bash .konjo/scripts/install-hooks.sh   # install Wall 1 pre-commit hook
   fixture *and* explicit sign-off.
 - **No secrets in code.** `creds.json`, `token.json`, `.env`, and refresh tokens live in env vars /
   Secret Manager only. They are git-ignored. Never write `token.json` to disk on the deployed path.
-- **Headless when launching locally; real browser only via a managed provider.** When Puppeteer
-  *launches* a browser (the `direct`/`proxy`/`unlocker` fetch strategies), it must use `headless: true`
-  and the container-safe flags (`--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage
-  --disable-gpu`) — no visible browser in our container/Cloud Run. The one sanctioned way to use a
-  *real (headed)* browser is `FETCH_STRATEGY=remote`, which `puppeteer.connect`s to a browser running
-  on a managed provider (Browserless / Browserbase) — the headed window runs on their infra, never
-  ours. (Signed off 2026-06-15: needed to get past UG's Cloudflare bot wall, which blocks headless
-  Chrome from any IP. See README → *Fetching past Cloudflare*.)
+- **Headless by default; a real (headed) browser only on sanctioned paths.** When Puppeteer *launches*
+  a browser it defaults to `headless: true` with the container-safe flags (`--no-sandbox
+  --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu`) — no visible browser in our
+  container/Cloud Run. Two sanctioned ways to use a *real (headed)* browser, both to get past UG's
+  Cloudflare wall (which blocks headless Chrome from any IP):
+  1. `FETCH_STRATEGY=remote` — `puppeteer.connect`s to a browser on a managed provider (Browserless /
+     Browserbase); the headed window runs on their infra, never ours. (Signed off 2026-06-15.)
+  2. `PUPPETEER_HEADLESS=false` — launch a headed browser on the **operator's own residential
+     hardware** (e.g. a Raspberry Pi under Xvfb) where the residential IP + real fingerprint clear
+     Cloudflare for free. The default stays `true`, so Cloud Run is unaffected. (Signed off 2026-06-15.
+     See docs/RASPBERRY_PI.md.)
 - **No timing hacks.** No `setTimeout`-based control flow. Use `await page.waitForSelector(...)` and
   awaited promises. Open and close the browser deterministically inside `scrapeSong`.
 - **`/scrape` is never open.** It requires the `x-api-key` shared-secret header and a validated

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ need a *residential IP* — the `remote` providers below bundle both.
 
 | `FETCH_STRATEGY` | Behavior | Use |
 |---|---|---|
-| `direct` (default) | Puppeteer navigates UG directly | local dev only — blocked on Cloud Run |
+| `direct` (default) | Puppeteer navigates UG directly, then waits out any interstitial | local dev; **also the free self-hosted path** — works on a residential host with a real (headed) browser (`PUPPETEER_HEADLESS=false`); blocked on Cloud Run's datacenter IP |
 | `proxy` | Puppeteer navigates through a residential/mobile proxy, then waits out the interstitial | cheaper, more tuning; set `PROXY_SERVER`/`PROXY_USERNAME`/`PROXY_PASSWORD` |
 | `unlocker` | a web-unlocker API returns rendered HTML (solves Cloudflare + TLS fingerprint + proxies) loaded via `setContent` | set `UNLOCKER_API_URL`/`UNLOCKER_API_KEY` |
 | `remote` | `puppeteer.connect`s to a **real browser** on a managed provider (Browserless / Browserbase) with stealth + residential IPs built in | **recommended** for Cloud Run — closest to "a real browser window", highest Cloudflare pass rate |
@@ -101,6 +101,14 @@ Two ways to point at a managed browser (resolved by `resolveRemoteEndpoint`):
   finishes (`browser.close()`), which also stops proxy billing.
 
 `REMOTE_BROWSER_WS_ENDPOINT` wins if both are configured.
+
+### Free, self-hosted: a Raspberry Pi at home (`direct` + a real browser)
+
+The zero-cost option. A Pi on your home network already has the two things Cloudflare wants — a
+**residential IP** and somewhere to run a **real browser** — so `FETCH_STRATEGY=direct` works with no
+paid provider. Set `PUPPETEER_HEADLESS=false` and run the headed Chrome under a virtual display
+(Xvfb), since the Pi is monitor-less. The default stays headless, so Cloud Run is untouched. Full
+walkthrough (install, `systemd`, phone trigger): **[docs/RASPBERRY_PI.md](docs/RASPBERRY_PI.md)**.
 
 ## Endpoints
 

--- a/docs/RASPBERRY_PI.md
+++ b/docs/RASPBERRY_PI.md
@@ -1,0 +1,177 @@
+# Self-hosting songscraper on a Raspberry Pi (free, no paid provider)
+
+This is the **zero-cost** way to run songscraper. A Raspberry Pi at home gives you the two things
+Ultimate Guitar's Cloudflare wall demands — for free:
+
+1. **A residential IP** — your home internet, which Cloudflare trusts (datacenter IPs get blocked).
+2. **A place to run a _real_ browser** — UG blocks *headless* Chrome even from a residential IP, so we
+   run a **real (headed) Chrome** under a **virtual display (Xvfb)**, since the Pi has no monitor.
+
+Residential IP + real browser fingerprint = the plain `FETCH_STRATEGY=direct` path works, with **no
+proxy, no unlocker, and no managed-browser bill**. The always-on Pi is also what makes it
+phone-triggerable without any other computer running.
+
+> Trade-off vs. the cloud: the Pi must stay powered on (it's a server, so it already is), and you
+> manage the box yourself. In exchange, the only ongoing cost is the electricity you're already
+> paying. See `DEPLOY.md` for the paid Cloud Run + managed-browser alternative.
+
+---
+
+## 0. What you need
+
+- A Raspberry Pi (Pi 4 / Pi 5 with 2 GB+ RAM recommended — Chrome is memory-hungry) running a recent
+  64-bit Raspberry Pi OS / Debian (Bookworm).
+- The Pi on your home network (Ethernet or Wi-Fi).
+- Your Google OAuth client (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`) and a **refresh token** — see
+  `DEPLOY.md` §5 (you can run the one-time `/auth` bootstrap locally and copy the token to the Pi).
+
+---
+
+## 1. Install Node 22, Chromium, and Xvfb
+
+Puppeteer's bundled Chrome has **no Linux/ARM desktop build**, so on a Pi you must use the system
+Chromium and tell Puppeteer to skip its own download (step 2). Install everything from apt:
+
+```bash
+# Node 22 (NodeSource)
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# System Chromium + a virtual display + fonts Chrome needs to render
+sudo apt-get install -y chromium xvfb fonts-liberation
+
+# Confirm the Chromium path (usually /usr/bin/chromium; older OSes: /usr/bin/chromium-browser)
+which chromium || which chromium-browser
+```
+
+---
+
+## 2. Get the code and install dependencies
+
+```bash
+git clone https://github.com/konjoinfinity/songscraper.git
+cd songscraper
+
+# Skip Puppeteer's (nonexistent on ARM) Chromium download — we use the system one.
+PUPPETEER_SKIP_DOWNLOAD=true npm ci --omit=dev
+```
+
+---
+
+## 3. Configure `.env`
+
+Copy the example and fill it in. The Pi-specific lines are the last three:
+
+```bash
+cp .env.example .env
+```
+
+```bash
+# .env (Pi)
+API_KEY=<a-long-random-string>            # the x-api-key your phone will send
+GOOGLE_CLIENT_ID=<...>.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=<...>
+OAUTH_REDIRECT_URI=http://localhost:8080/oauth2callback
+REFRESH_TOKEN=<the-long-lived-refresh-token>
+TEMPLATE_DOC_ID=1xM26IwbTj7L9VNXwDLyXV4ZWSdLUvRybDclq_u46My4
+
+# ── The Raspberry Pi browser settings ──
+FETCH_STRATEGY=direct                     # navigate UG directly from your residential IP
+PUPPETEER_HEADLESS=false                  # launch a REAL (headed) browser — beats the headless block
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium   # the system Chromium from step 1
+```
+
+> `.env` holds secrets — it is git-ignored; never commit it.
+
+---
+
+## 4. Test it under Xvfb
+
+`xvfb-run` starts a throwaway virtual display and runs the command inside it, so the headed Chrome has
+somewhere to draw:
+
+```bash
+xvfb-run -a node src/server.js
+```
+
+In another terminal (on the Pi), scrape a song:
+
+```bash
+curl -X POST http://localhost:8080/scrape \
+  -H "x-api-key: $API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"url":"https://tabs.ultimate-guitar.com/tab/.../...-chords-..."}'
+# -> { "docUrl": "...", "title": "...", "artist": "..." }
+```
+
+If you get a Google Doc link back, you're done — Cloudflare let the real browser through.
+
+---
+
+## 5. Run it always-on with systemd
+
+So it survives reboots and starts the virtual display for you. Create
+`/etc/systemd/system/songscraper.service` (adjust `User` and `WorkingDirectory`):
+
+```ini
+[Unit]
+Description=songscraper (Ultimate Guitar -> Google Docs)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/songscraper
+EnvironmentFile=/home/pi/songscraper/.env
+# xvfb-run wraps node in a virtual display so the headed Chrome can render.
+ExecStart=/usr/bin/xvfb-run -a /usr/bin/node src/server.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now songscraper
+systemctl status songscraper          # should be "active (running)"
+journalctl -u songscraper -f          # live logs
+```
+
+---
+
+## 6. Trigger it from your phone
+
+The service now listens on the Pi's port 8080. How your phone reaches it depends on where you are:
+
+- **On your home Wi-Fi (simplest):** point the iOS Shortcut (`docs/MOBILE.md`) at the Pi's LAN address,
+  e.g. `http://192.168.1.50:8080/scrape`. Give the Pi a static/reserved IP in your router so it
+  doesn't change.
+- **From anywhere (recommended): [Tailscale](https://tailscale.com).** Install it on the Pi and your
+  phone (both free); the phone then reaches the Pi at its private Tailscale IP from any network, with
+  no port-forwarding and nothing exposed to the public internet.
+- **From anywhere, public URL: a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)**
+  (or similar) gives the Pi an HTTPS URL without opening router ports. Only do this with the `x-api-key`
+  guard on (it is) — the endpoint is then internet-reachable.
+
+> Whichever you pick, the `x-api-key` shared secret + UG-URL validation remain the auth boundary —
+> never run the service without `API_KEY` set.
+
+---
+
+## Troubleshooting
+
+- **Still getting a "Blocked by anti-bot protection" error.** Confirm `PUPPETEER_HEADLESS=false` is set
+  (a headless browser is blocked even on a residential IP) and that you're launching via `xvfb-run`.
+  Verify the IP really is residential (a VPN on the Pi can route you out a flagged datacenter IP).
+- **`Failed to launch the browser process` / no display.** You ran `node` directly instead of through
+  `xvfb-run`, or `xvfb` isn't installed. Re-check step 1 and use `xvfb-run -a`.
+- **Chromium path wrong.** If `which chromium` is empty, your OS ships `chromium-browser`; set
+  `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser`.
+- **Out of memory / Chrome crashes on a Pi with little RAM.** Close other services, or add swap. The
+  container-safe flags (`--disable-dev-shm-usage` etc.) are already applied.
+- **Cloudflare hardens and even the headed browser is challenged.** As a next step you can add a
+  stealth layer (e.g. `puppeteer-extra` + the stealth plugin) — this is intentionally not a dependency
+  today to keep the tree lean. Open an issue if you hit this.

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ const {
   TEMPLATE_DOC_ID,
   DRIVE_FOLDER_ID,
   PUPPETEER_EXECUTABLE_PATH,
+  PUPPETEER_HEADLESS,
   SCRAPE_STRATEGY,
   DETECT_MIN_SCORE,
   FETCH_STRATEGY,
@@ -52,7 +53,12 @@ export const config = {
   driveFolderId: DRIVE_FOLDER_ID || '',
 
   puppeteer: {
-    headless: true,
+    // Headless by default (container/Cloud Run). Set PUPPETEER_HEADLESS=false to
+    // launch a *real* (headed) Chrome — the sanctioned self-hosted path: on your
+    // own residential hardware (e.g. a Raspberry Pi under Xvfb), where UG's
+    // Cloudflare wall lets a real browser on a residential IP through. See
+    // docs/RASPBERRY_PI.md. Only `false` flips it; anything else stays headless.
+    headless: PUPPETEER_HEADLESS !== 'false',
     // Container-safe flags. --no-sandbox is required to run Chromium as root in a container.
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
     executablePath: PUPPETEER_EXECUTABLE_PATH || undefined,

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -148,11 +148,28 @@ export async function resolveRemoteEndpoint() {
 }
 
 /**
+ * Build the `puppeteer.launch` options for a fetch strategy. Pure (no I/O) so it
+ * can be asserted in tests. `headless` follows config (real/headed only on the
+ * self-hosted PUPPETEER_HEADLESS=false path); `args` adds the proxy server when
+ * the proxy strategy is configured.
+ * @param {string} [strategy=config.fetchStrategy]
+ * @returns {{ headless: boolean, args: string[], executablePath: (string|undefined) }}
+ */
+export function launchOptions(strategy = config.fetchStrategy) {
+  return {
+    headless: config.puppeteer.headless,
+    args: [...config.puppeteer.args, ...launchArgs(strategy)],
+    executablePath: config.puppeteer.executablePath,
+  };
+}
+
+/**
  * Acquire a Puppeteer browser for the configured fetch strategy. For `remote`,
  * connect to a managed real browser; otherwise launch a local/container Chromium
- * with the headless container-safe flags. The caller (scrapeSong) owns the
- * lifecycle and closes it deterministically — `browser.close()` works for both a
- * launched and a connected browser (and ends the remote session).
+ * (headless by default, or a real headed browser when PUPPETEER_HEADLESS=false on
+ * a self-hosted residential host). The caller (scrapeSong) owns the lifecycle and
+ * closes it deterministically — `browser.close()` works for both a launched and a
+ * connected browser (and ends the remote session).
  * @param {string} [strategy=config.fetchStrategy]
  * @returns {Promise<import('puppeteer').Browser>}
  */
@@ -161,11 +178,7 @@ export async function createBrowserSession(strategy = config.fetchStrategy) {
     const browserWSEndpoint = await resolveRemoteEndpoint();
     return puppeteer.connect({ browserWSEndpoint });
   }
-  return puppeteer.launch({
-    headless: config.puppeteer.headless,
-    args: [...config.puppeteer.args, ...launchArgs(strategy)],
-    executablePath: config.puppeteer.executablePath,
-  });
+  return puppeteer.launch(launchOptions(strategy));
 }
 
 /**
@@ -215,11 +228,11 @@ export async function loadChartPage(browser, url, strategy = config.fetchStrateg
   }
 
   await page.goto(url, { waitUntil: 'networkidle2' });
-  if (strategy === 'proxy' || strategy === 'remote') {
-    // The provider's browser usually clears Cloudflare itself, but wait out any
-    // residual interstitial before reading the chart.
-    await waitForChallengeToClear(page);
-  }
+  // Wait out any Cloudflare interstitial before reading the chart. A real headed
+  // browser (proxy/remote, or the self-hosted PUPPETEER_HEADLESS=false path on a
+  // residential IP) solves the JS challenge within a few seconds; this resolves
+  // immediately when there is no challenge, so it is harmless on a clean load.
+  await waitForChallengeToClear(page);
   // Best-effort: wait on the known render signal, but don't fail if it has rotted.
   await page.waitForSelector(selectors.ready).catch(() => null);
   return page;

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import {
   isChallengePage,
   launchArgs,
+  launchOptions,
   fetchViaUnlocker,
   loadChartPage,
   resolveRemoteEndpoint,
@@ -85,14 +86,29 @@ describe('launchArgs', () => {
   });
 });
 
+describe('launchOptions (no env)', () => {
+  it('defaults to headless with the container-safe flags and no executablePath', () => {
+    const opts = launchOptions('direct');
+    expect(opts.headless).toBe(true);
+    expect(opts.args).toEqual([
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+    ]);
+    expect(opts.executablePath).toBeUndefined();
+  });
+});
+
 describe('loadChartPage — strategy wiring (no env)', () => {
-  it('direct: navigates to the URL and never uses setContent', async () => {
+  it('direct: navigates, waits out any interstitial, and never uses setContent', async () => {
     const page = makeFakePage();
     await loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'direct');
     expect(page._calls.goto).toHaveLength(1);
     expect(page._calls.goto[0][0]).toBe('https://ug/x');
     expect(page._calls.setContent).toHaveLength(0);
     expect(page._calls.waitForSelector).toBe(1);
+    expect(page._calls.waitForFunction).toBe(1); // the challenge-clear wait
   });
 
   it('proxy: navigates and waits out the challenge interstitial', async () => {
@@ -183,6 +199,34 @@ describe('unlocker path (env-configured)', () => {
     const page = makeFakePage();
     await mod.loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'proxy');
     expect(page._calls.authenticate).toEqual([{ username: 'user', password: 'pass' }]);
+  });
+});
+
+describe('launchOptions — self-hosted headed browser (env-configured)', () => {
+  const OLD_ENV = process.env;
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('launches a real (headed) browser when PUPPETEER_HEADLESS=false', async () => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      PUPPETEER_HEADLESS: 'false',
+      PUPPETEER_EXECUTABLE_PATH: '/usr/bin/chromium',
+    };
+    const mod = await import('../src/fetcher.js');
+    const opts = mod.launchOptions('direct');
+    expect(opts.headless).toBe(false);
+    expect(opts.executablePath).toBe('/usr/bin/chromium');
+    expect(opts.args).toContain('--no-sandbox');
+  });
+
+  it('stays headless for any value other than the literal "false"', async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, PUPPETEER_HEADLESS: 'true' };
+    const mod = await import('../src/fetcher.js');
+    expect(mod.launchOptions('direct').headless).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to #14. That PR added a paid managed-browser path; this one adds the **zero-cost** path: run songscraper on a **Raspberry Pi at home**.

A Pi already has the two things Ultimate Guitar's Cloudflare wall demands — a **residential IP** (your home internet) and somewhere to run a **real browser** — so the plain `FETCH_STRATEGY=direct` path works with **no proxy, no unlocker, no managed-browser bill**. The only catch is that UG blocks *headless* Chrome even from a residential IP, so we run a **real (headed) Chrome under Xvfb** (the Pi is monitor-less).

## What changed

- **`src/config.js`** — new `PUPPETEER_HEADLESS` env flag. Default stays `true` (Cloud Run/container untouched); only the literal `false` launches a headed browser.
- **`src/fetcher.js`** —
  - Extracted a pure, unit-testable `launchOptions()` (headless flag + container-safe args + executablePath).
  - The `direct` navigation now **waits out a transient Cloudflare interstitial** before reading the chart — a real headed browser auto-solves the JS challenge in a few seconds, instead of failing immediately. (Resolves instantly on a clean load, so local dev is unaffected.)
- **`docs/RASPBERRY_PI.md`** (new) — full walkthrough: install Node 22 + system Chromium + Xvfb, `.env` config, run always-on via `systemd` + `xvfb-run`, and trigger from your phone (home Wi-Fi, or anywhere via Tailscale / Cloudflare Tunnel). Plus troubleshooting.
- **`README.md` / `.env.example`** — document the flag and the free Pi path.
- **`CLAUDE.md`** — dated sign-off amending the headless rule to sanction a headed browser on the operator's **own residential hardware** (the Cloud Run default remains headless).

## Tests

New cases in `test/fetcher.test.js`: `launchOptions` defaults (headless + flags + no executablePath), `PUPPETEER_HEADLESS=false` → headed with a custom `executablePath`, non-`false` stays headless, and `direct` now runs the challenge-clear wait. Full suite: **58/58 pass**, lint + prettier clean, Crown-Jewels fixture untouched.

## Trade-off

The Pi must stay powered on (it's a server, so it already is) and you manage the box — in exchange the only ongoing cost is electricity. The paid Cloud Run + managed-browser route from #14 remains documented in `DEPLOY.md` for those who'd rather not self-host.


---
_Generated by [Claude Code](https://claude.ai/code/session_019zWvbLTwyjgsrJwBWFeLGB)_