### PR TITLE
docs(mobile): document Pi + Tailscale flow and add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,40 @@ Google with a stored OAuth refresh token (zero human interaction per run). Trigg
 
 ## Architecture
 
+A single `POST /scrape` drives the whole pipeline: a real browser clears Cloudflare, the chart is
+located heuristically, the Crown-Jewels formatter builds the Docs payload, and a Google Doc link comes
+back. The two deployment shapes differ only in **where the real browser runs** — a self-hosted Pi on a
+residential IP (free), or a managed remote browser from Cloud Run (paid).
+
+```mermaid
+flowchart LR
+    phone["📱 iPhone<br/>Shortcut / Share Sheet"]
+
+    subgraph pi["🥧 Raspberry Pi · home · residential IP"]
+        direction TB
+        ex["server.js<br/>x-api-key guard<br/>+ UG-URL validation"]
+        fe["fetcher.js<br/>headed Chrome under Xvfb"]
+        det["detect.js<br/>heuristic chord-block scoring"]
+        fmt["formatter.js<br/>Crown Jewels batchUpdate"]
+        ex --> fe --> det --> fmt
+    end
+
+    ug["🎸 Ultimate Guitar<br/>behind Cloudflare"]
+    g["📄 Google Docs + Drive API"]
+
+    phone -->|"POST /scrape { url }<br/>over Tailscale (WireGuard)"| ex
+    fe <-->|"real browser +<br/>residential IP clears the wall"| ug
+    fmt -->|"copy template → batchUpdate →<br/>unbold pass"| g
+    g -.->|"docUrl"| ex
+    ex -.->|"{ docUrl, title, artist }"| phone
+```
+
+> On Cloud Run the `fetcher.js` box instead `puppeteer.connect`s to a managed remote browser
+> (`FETCH_STRATEGY=remote`) — datacenter IPs are blocked, so the headed browser + residential egress
+> are rented. Everything downstream (detect → format → Docs) is identical.
+
+### Module layout
+
 ```
 src/
   server.js        Express app + routes + API-key guard + URL validation
@@ -164,6 +198,18 @@ CI/CD: PRs are gated by `.github/workflows/ci.yml` and merges to `main` auto-dep
 `POST /scrape` is all a phone needs. See **[docs/MOBILE.md](./docs/MOBILE.md)** for an **iOS Shortcut**
 that takes a shared Ultimate Guitar link from the Share Sheet, calls the service with the `x-api-key`,
 and opens the finished Google Doc.
+
+How the phone reaches the service depends on the deployment:
+
+| Deployment | Endpoint the Shortcut calls | Reachable from |
+|---|---|---|
+| **Pi + [Tailscale](https://tailscale.com)** (free, recommended) | `http://<pi-name>.<tailnet>.ts.net:8080/scrape` | anywhere (encrypted, nothing public) |
+| **Pi on home Wi-Fi** | `http://<pi-lan-ip>:8080/scrape` | home network only |
+| **Cloud Run** | `https://<cloud-run-url>/scrape` | anywhere (public HTTPS) |
+
+For the self-hosted path, Tailscale is the sweet spot: a private WireGuard link to the Pi from any
+network, no port-forwarding, nothing exposed to the public internet. Full walkthrough in
+**[docs/MOBILE.md](./docs/MOBILE.md)** and **[docs/RASPBERRY_PI.md](./docs/RASPBERRY_PI.md)**.
 
 ## Out of scope (deferred)
 

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -4,13 +4,62 @@ songscraper needs no app and no new code to be driven from a phone. `POST /scrap
 returns `{ docUrl, title, artist }`, so an **iOS Shortcut** can take a shared Ultimate Guitar link,
 call the service, and open the finished Google Doc.
 
-## Prerequisites
+The scrape always runs **wherever the real browser lives** — your Raspberry Pi (free, residential IP)
+or a managed remote browser behind Cloud Run. The phone just makes one HTTP call to it. The only thing
+that changes between setups is the **URL** the Shortcut posts to.
 
-- The service deployed and reachable at a public HTTPS URL (Cloud Run). For the Shortcut to call it
-  without a Google identity token, deploy with `--allow-unauthenticated` — the service stays protected
-  by the `x-api-key` shared secret + UG-URL validation (see `DEPLOY.md` §7). The API key **is** the
-  auth boundary.
-- Your `API_KEY` value (the same secret the service checks). Treat it like a password.
+```mermaid
+sequenceDiagram
+    actor You
+    participant SS as iOS Shortcut
+    participant Svc as songscraper<br/>(Pi or Cloud Run)
+    participant UG as Ultimate Guitar
+    participant G as Google Docs/Drive
+
+    You->>SS: Share a UG chord link → "Scrape Song"
+    SS->>Svc: POST /scrape { url } + x-api-key
+    Note over Svc,UG: real browser on a residential IP<br/>clears the Cloudflare wall
+    Svc->>UG: load chart, extract text
+    Svc->>G: copy template → batchUpdate → unbold pass
+    G-->>Svc: docUrl
+    Svc-->>SS: { docUrl, title, artist }
+    SS->>You: open the Google Doc
+```
+
+## Pick your endpoint
+
+| Setup | Shortcut URL | Reachable from | Notes |
+|---|---|---|---|
+| **Pi + [Tailscale](https://tailscale.com)** (recommended) | `http://<pi-name>.<tailnet>.ts.net:8080/scrape` | anywhere | private WireGuard link; nothing public. `http` is fine — Tailscale encrypts the transport. |
+| **Pi on home Wi-Fi** | `http://<pi-lan-ip>:8080/scrape` | home network only | give the Pi a reserved IP in your router. |
+| **Cloud Run** | `https://<cloud-run-url>/scrape` | anywhere | deploy with `--allow-unauthenticated`; the `x-api-key` is the auth boundary (see `DEPLOY.md` §7). |
+
+> The `x-api-key` shared secret + UG-URL validation are the auth boundary in **every** setup. Never run
+> the service without `API_KEY` set, and treat the key like a password.
+>
+> **Port note:** `8080` is the default. If something else already owns `8080` on your box (e.g. an
+> Umbrel home server), set `PORT` in `.env` to a free port and use that in the URL instead.
+
+### Recommended: Pi + Tailscale (free, works anywhere)
+
+[Tailscale](https://tailscale.com) puts the Pi and your phone on the same private network from any
+location, with no port-forwarding and nothing exposed to the public internet. One-time setup:
+
+1. **On the Pi:** `curl -fsSL https://tailscale.com/install.sh | sh`, then
+   `sudo tailscale up --hostname=songscraper`. Open the printed login URL and approve the machine.
+2. **On the iPhone:** install **Tailscale** from the App Store, sign in with the **same account**, and
+   toggle the VPN **on**.
+3. **Find the Pi's name:** `tailscale status` (or the admin console) shows its MagicDNS name, e.g.
+   `songscraper.tailXXXXXX.ts.net`. Your Shortcut URL is
+   `http://songscraper.tailXXXXXX.ts.net:8080/scrape` (the Tailscale `100.x.y.z` IP works too).
+
+The Pi re-joins the tailnet automatically after a reboot — no re-auth needed. Full Pi install in
+**[RASPBERRY_PI.md](RASPBERRY_PI.md)**.
+
+> **Note on Cloud Run.** A normal Cloud Run deploy cannot scrape Ultimate Guitar by itself —
+> Cloudflare blocks the datacenter IP. It only works with `FETCH_STRATEGY=remote` (a paid managed
+> browser with residential egress). The free path is the Pi. See the README's *Fetching past
+> Cloudflare* section.
 
 ## Build the Shortcut
 
@@ -27,7 +76,7 @@ Open **Shortcuts → + (new) → rename it e.g. "Scrape Song"**, then add these 
    in the request body.)
 
 4. **Get Contents of URL**:
-   - **URL**: `https://<your-cloud-run-url>/scrape`
+   - **URL**: your endpoint from the table above (e.g. `http://<pi-name>.<tailnet>.ts.net:8080/scrape`)
    - **Method**: `POST`
    - **Headers**:
      - `x-api-key` = `<YOUR_API_KEY>`
@@ -41,6 +90,10 @@ Open **Shortcuts → + (new) → rename it e.g. "Scrape Song"**, then add these 
    - Optional: add **Show Notification** with the `title` and `artist` dictionary values for a
      confirmation toast instead of (or before) opening.
 
+> **Timeouts.** A scrape takes ~20–60s (a real browser clears Cloudflare, then two Google Docs
+> passes). If the Shortcut appears to time out, the scrape usually still finished and the doc is in
+> your Drive — check Drive before re-running.
+
 ## Use it
 
 - From Safari or the UG app, open a chord chart → **Share** → **Scrape Song** → the Doc opens.
@@ -50,7 +103,7 @@ Open **Shortcuts → + (new) → rename it e.g. "Scrape Song"**, then add these 
 
 ```http
 POST /scrape
-Host: <your-cloud-run-url>
+Host: <your-endpoint>
 x-api-key: <YOUR_API_KEY>
 Content-Type: application/json
 
@@ -68,7 +121,11 @@ Errors: `401` (missing/invalid `x-api-key`), `400` (not a valid `ultimate-guitar
 ## Security notes
 
 - The `x-api-key` stored in the Shortcut grants scrape access. If a device is lost or the key leaks,
-  rotate it: add a new `API_KEY` secret version and redeploy, then update the Shortcut.
+  rotate it: set a new `API_KEY` (in `.env` on the Pi, or a new Secret Manager version on Cloud Run),
+  restart/redeploy, then update the Shortcut.
+- Tailscale keeps the Pi off the public internet entirely; prefer it over port-forwarding or a public
+  tunnel. If you do expose a public URL, keep the `x-api-key` guard on (it is) and consider adding an
+  identity layer (e.g. Cloudflare Access) in front.
 - Keep the URL validation and the constant-time key check (already in `src/server.js`) — never expose
   `/scrape` without the key.
 

--- a/docs/RASPBERRY_PI.md
+++ b/docs/RASPBERRY_PI.md
@@ -169,15 +169,37 @@ The service now listens on the Pi's port 8080. How your phone reaches it depends
 - **On your home Wi-Fi (simplest):** point the iOS Shortcut (`docs/MOBILE.md`) at the Pi's LAN address,
   e.g. `http://192.168.1.50:8080/scrape`. Give the Pi a static/reserved IP in your router so it
   doesn't change.
-- **From anywhere (recommended): [Tailscale](https://tailscale.com).** Install it on the Pi and your
-  phone (both free); the phone then reaches the Pi at its private Tailscale IP from any network, with
-  no port-forwarding and nothing exposed to the public internet.
+- **From anywhere (recommended): [Tailscale](https://tailscale.com).** A private WireGuard network
+  between the Pi and your phone — reachable from any network, no port-forwarding, nothing exposed to
+  the public internet. Setup below.
 - **From anywhere, public URL: a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)**
   (or similar) gives the Pi an HTTPS URL without opening router ports. Only do this with the `x-api-key`
-  guard on (it is) — the endpoint is then internet-reachable.
+  guard on (it is) — the endpoint is then internet-reachable; consider an identity layer (Cloudflare
+  Access) in front.
 
 > Whichever you pick, the `x-api-key` shared secret + UG-URL validation remain the auth boundary —
-> never run the service without `API_KEY` set.
+> never run the service without `API_KEY` set. Over Tailscale, plain `http` is fine — the transport is
+> already encrypted by WireGuard.
+
+### Tailscale, step by step (the recommended path)
+
+```bash
+# On the Pi
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo systemctl enable --now tailscaled        # ensure the daemon is running
+sudo tailscale up --hostname=songscraper      # prints a login URL — open it, approve the machine
+tailscale status                              # shows the Pi's MagicDNS name + 100.x.y.z IP
+```
+
+Then on the **iPhone**: install **Tailscale** from the App Store, sign in with the **same account**,
+and toggle the VPN **on**. Point the Shortcut at the Pi's MagicDNS name:
+
+```
+http://songscraper.tailXXXXXX.ts.net:8080/scrape      # the 100.x.y.z Tailscale IP works too
+```
+
+`tailscaled` is enabled, and the Pi stays authenticated across reboots, so it re-joins the tailnet
+automatically — no re-auth needed. Full Shortcut build: **[MOBILE.md](MOBILE.md)**.
 
 ---
 
@@ -192,6 +214,9 @@ The service now listens on the Pi's port 8080. How your phone reaches it depends
   `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser`.
 - **Out of memory / Chrome crashes on a Pi with little RAM.** Close other services, or add swap. The
   container-safe flags (`--disable-dev-shm-usage` etc.) are already applied.
+- **Port 8080 already in use (e.g. on an Umbrel home server).** Another service may own `8080`
+  (`sudo ss -ltnp | grep :8080` to see what). Set `PORT=8090` (or any free port) in `.env`,
+  `sudo systemctl restart songscraper`, and use that port in the scrape URL and the iOS Shortcut.
 - **Cloudflare hardens and even the headed browser is challenged.** As a next step you can add a
   stealth layer (e.g. `puppeteer-extra` + the stealth plugin) — this is intentionally not a dependency
   today to keep the tree lean. Open an issue if you hit this.


### PR DESCRIPTION
## What & why

The mobile guide assumed a public **Cloud Run** URL, but a datacenter deploy can't clear Ultimate Guitar's Cloudflare wall — the scrape must run on the **residential-IP Pi**. These docs now match how the service is actually run self-hosted, and add the requested architecture diagram.

## Changes

- **README.md**
  - Mermaid **runtime architecture diagram** (phone → Tailscale → Pi pipeline → Google Docs/Drive).
  - New `### Module layout` subheading over the existing file tree.
  - "Trigger from your phone" endpoint table: Pi+Tailscale / home Wi-Fi / Cloud Run.
- **docs/MOBILE.md**
  - Leads with the **Pi + Tailscale** path; keeps Cloud Run as an option with the Cloudflare caveat.
  - Mermaid **sequence diagram** of the Share-Sheet → service → Google flow.
  - Per-deployment endpoint table, Tailscale setup steps, and notes on http-over-WireGuard, ~20–60s scrape timeouts, and the `PORT` default.
- **docs/RASPBERRY_PI.md**
  - Tailscale section expanded into a step-by-step walkthrough.
  - Troubleshooting entry for **port 8080 already in use** (e.g. Umbrel) → set `PORT`.

## Notes

- Docs-only. No source or formatter (Crown Jewels) changes.
- `npm run lint` clean; `npm test` 48 passed, 10 e2e skipped (no local Chromium).
- No secrets or personal hostnames/keys committed — all placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)