### PR TITLE
perf(scrape): warm browser process, faster navigation, cached auth client

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -198,7 +198,7 @@ export async function createBrowserSession(strategy = config.fetchStrategy) {
  * @returns {Promise<import('puppeteer').Browser>}
  */
 export async function getBrowser(launch = () => puppeteer.launch(launchOptions())) {
-  if (sharedBrowser && sharedBrowser.connected) {
+  if (sharedBrowser?.connected) {
     return sharedBrowser;
   }
   sharedBrowser = await launch();
@@ -215,7 +215,7 @@ export async function getBrowser(launch = () => puppeteer.launch(launchOptions()
 export async function closeSharedBrowser() {
   const browser = sharedBrowser;
   sharedBrowser = null;
-  if (browser && browser.connected) {
+  if (browser?.connected) {
     await browser.close().catch(() => null);
   }
 }

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -22,6 +22,14 @@
 import puppeteer from 'puppeteer';
 import { config, selectors } from './config.js';
 
+// A single long-lived browser process, reused across scrapes so the ~3.5s Chrome
+// launch is paid once (at startup) rather than on every request. Each scrape gets
+// a *fresh, isolated* BrowserContext (see openChart) — never a shared cookie jar:
+// persisting Cloudflare cookies across visits provokes a hard challenge that never
+// clears (measured: 75s timeout vs ~12s with fresh contexts). null when no browser
+// is alive; relaunched lazily on next use.
+let sharedBrowser = null;
+
 // Markers of a Cloudflare (or similar) bot-check interstitial, matched against
 // the page title and/or a snippet of the HTML. Kept deliberately broad.
 const CHALLENGE_MARKERS = [
@@ -182,6 +190,70 @@ export async function createBrowserSession(strategy = config.fetchStrategy) {
 }
 
 /**
+ * Return the shared, warm browser process, launching it on first use and after a
+ * crash. Only for *local* launches (direct/proxy/unlocker) — the `remote` strategy
+ * is per-scrape (managed sessions, esp. Browserbase) and is handled in openChart.
+ * The `disconnected` listener drops the cached handle so the next call relaunches.
+ * @param {() => Promise<import('puppeteer').Browser>} [launch] - injectable launcher (tests)
+ * @returns {Promise<import('puppeteer').Browser>}
+ */
+export async function getBrowser(launch = () => puppeteer.launch(launchOptions())) {
+  if (sharedBrowser && sharedBrowser.connected) {
+    return sharedBrowser;
+  }
+  sharedBrowser = await launch();
+  sharedBrowser.once('disconnected', () => {
+    sharedBrowser = null;
+  });
+  return sharedBrowser;
+}
+
+/**
+ * Close and forget the shared browser. Call on shutdown; also a test seam.
+ * @returns {Promise<void>}
+ */
+export async function closeSharedBrowser() {
+  const browser = sharedBrowser;
+  sharedBrowser = null;
+  if (browser && browser.connected) {
+    await browser.close().catch(() => null);
+  }
+}
+
+/**
+ * Acquire a loaded chart page plus a `release` to free its resources. For local
+ * strategies this reuses the warm browser and isolates the scrape in a throwaway
+ * BrowserContext (fresh cookies → no Cloudflare cross-visit penalty); release()
+ * closes only that context, leaving the browser warm. For `remote`, a fresh
+ * connection is made per scrape and release() closes it (ending the session).
+ * @param {string} url - a validated ultimate-guitar.com chart URL
+ * @param {string} [strategy=config.fetchStrategy]
+ * @returns {Promise<{ page: import('puppeteer').Page, release: () => Promise<void> }>}
+ */
+export async function openChart(url, strategy = config.fetchStrategy) {
+  if (strategy === 'remote') {
+    const browser = await createBrowserSession(strategy);
+    try {
+      const page = await loadChartPage(browser, url, strategy);
+      return { page, release: () => browser.close().catch(() => null) };
+    } catch (err) {
+      await browser.close().catch(() => null);
+      throw err;
+    }
+  }
+
+  const browser = await getBrowser();
+  const context = await browser.createBrowserContext();
+  try {
+    const page = await loadChartPage(context, url, strategy);
+    return { page, release: () => context.close().catch(() => null) };
+  } catch (err) {
+    await context.close().catch(() => null);
+    throw err;
+  }
+}
+
+/**
  * Wait (bounded, condition-based — no timers) for a Cloudflare interstitial to
  * resolve to the real page. Resolves as soon as the title no longer matches a
  * challenge marker; gives up quietly on timeout so the caller's challenge guard
@@ -203,7 +275,7 @@ async function waitForChallengeToClear(page) {
  * Open `url` and return a Puppeteer page holding the chart's DOM, using the
  * configured fetch strategy. The browser is owned by the caller (scrapeSong),
  * which closes it deterministically; this only creates and loads the page.
- * @param {import('puppeteer').Browser} browser
+ * @param {import('puppeteer').Browser|import('puppeteer').BrowserContext} browser - anything with newPage()
  * @param {string} url - a validated ultimate-guitar.com chart URL
  * @param {string} [strategy=config.fetchStrategy]
  * @returns {Promise<import('puppeteer').Page>}
@@ -227,7 +299,13 @@ export async function loadChartPage(browser, url, strategy = config.fetchStrateg
     });
   }
 
-  await page.goto(url, { waitUntil: 'networkidle2' });
+  // `domcontentloaded` (not `networkidle2`): UG is ad/tracker-heavy, so waiting
+  // for the network to fall idle adds ~5s of pure waste — the chart <pre> and the
+  // Cloudflare challenge both settle long before the ad sockets go quiet. We gate
+  // explicitly below on the challenge-clear and the `pre` render signal instead,
+  // which is both faster and a more honest readiness check. (Measured on a Pi 4:
+  // ~21s networkidle2 nav vs ~12-15s domcontentloaded + these waits.)
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
   // Wait out any Cloudflare interstitial before reading the chart. A real headed
   // browser (proxy/remote, or the self-hosted PUPPETEER_HEADLESS=false path on a
   // residential IP) solves the JS challenge within a few seconds; this resolves

--- a/src/google/auth.js
+++ b/src/google/auth.js
@@ -25,20 +25,40 @@ function makeOAuthClient() {
   );
 }
 
+// Memoized authorized client. The OAuth2 client caches its short-lived access
+// token and auto-refreshes when it expires, so reusing one instance across
+// requests avoids re-minting an access token on every scrape (one fewer Google
+// round trip per request). Reset via resetAuthorizedClient (test seam / rotation).
+let authorizedClient = null;
+
 /**
  * An authorized client for normal runs: loads the stored refresh token and lets
- * googleapis auto-refresh the access token. Throws clearly if no token is set.
+ * googleapis auto-refresh the access token. Memoized so the access token is reused
+ * across requests. Throws clearly if no token is set.
  * @returns {import('google-auth-library').OAuth2Client}
  */
 export function getAuthorizedClient() {
   assertConfig(['clientId', 'clientSecret', 'refreshToken']);
+  if (authorizedClient) {
+    return authorizedClient;
+  }
   const client = new google.auth.OAuth2(
     config.oauth.clientId,
     config.oauth.clientSecret,
     config.oauth.redirectUri
   );
   client.setCredentials({ refresh_token: config.oauth.refreshToken });
+  authorizedClient = client;
   return client;
+}
+
+/**
+ * Drop the memoized authorized client so the next call rebuilds it (e.g. after a
+ * refresh-token rotation, or to isolate tests).
+ * @returns {void}
+ */
+export function resetAuthorizedClient() {
+  authorizedClient = null;
 }
 
 /**

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -4,7 +4,7 @@
 
 import { config, selectors } from './config.js';
 import { detectChordBlock, parseTitleFromDocTitle } from './detect.js';
-import { createBrowserSession, loadChartPage, isChallengePage } from './fetcher.js';
+import { openChart, isChallengePage } from './fetcher.js';
 
 /**
  * Read every match of `selector` and return the concatenated textContent.
@@ -60,17 +60,12 @@ export async function extractChordText(
  * @returns {Promise<{ title: string, artist: string, rawText: string }>}
  */
 export async function scrapeSong(url) {
-  let browser = null;
+  // Acquire a loaded chart page plus its `release`. For local strategies this
+  // reuses the warm browser process and isolates the scrape in a throwaway
+  // BrowserContext; for `remote` it is a per-scrape connection. release() frees
+  // the right resource (context or connection) — see fetcher.openChart.
+  const { page, release } = await openChart(url);
   try {
-    // Acquire the browser for the configured fetch strategy: a local headless
-    // Chromium for direct/proxy/unlocker, or a connection to a managed real
-    // browser for `remote`. Either way scrapeSong owns and closes it below.
-    browser = await createBrowserSession();
-
-    // Acquire the chart page via the configured fetch strategy (direct/proxy/
-    // unlocker). loadChartPage handles navigation, proxy auth, and the ready wait.
-    const page = await loadChartPage(browser, url);
-
     // Fail fast with a clear, actionable message if we got an anti-bot wall
     // instead of the chart (the unlocker path is expected to have solved it).
     if (config.fetchStrategy !== 'unlocker' && isChallengePage(await page.title())) {
@@ -105,9 +100,7 @@ export async function scrapeSong(url) {
 
     return { title, artist, rawText };
   } finally {
-    if (browser) {
-      await browser.close();
-    }
+    await release();
   }
 }
 

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+// getAuthorizedClient reads config (which reads process.env at import), so each
+// case sets the required OAuth env, resets the module registry, and dynamically
+// imports a fresh module. No network: constructing the OAuth2 client and setting
+// the refresh token does not mint an access token (that happens on first API call).
+describe('getAuthorizedClient — memoization', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      GOOGLE_CLIENT_ID: 'client-id',
+      GOOGLE_CLIENT_SECRET: 'client-secret',
+      OAUTH_REDIRECT_URI: 'http://localhost/oauth2callback',
+      REFRESH_TOKEN: 'refresh-token',
+    };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns the same client instance across calls (token reuse)', async () => {
+    const { getAuthorizedClient, resetAuthorizedClient } = await import('../src/google/auth.js');
+    resetAuthorizedClient();
+    const a = getAuthorizedClient();
+    const b = getAuthorizedClient();
+    expect(a).toBe(b);
+  });
+
+  it('rebuilds the client after resetAuthorizedClient (e.g. token rotation)', async () => {
+    const { getAuthorizedClient, resetAuthorizedClient } = await import('../src/google/auth.js');
+    resetAuthorizedClient();
+    const a = getAuthorizedClient();
+    resetAuthorizedClient();
+    const b = getAuthorizedClient();
+    expect(a).not.toBe(b);
+  });
+});

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -25,17 +25,17 @@ describe('getAuthorizedClient — memoization', () => {
   it('returns the same client instance across calls (token reuse)', async () => {
     const { getAuthorizedClient, resetAuthorizedClient } = await import('../src/google/auth.js');
     resetAuthorizedClient();
-    const a = getAuthorizedClient();
-    const b = getAuthorizedClient();
-    expect(a).toBe(b);
+    const first = getAuthorizedClient();
+    const second = getAuthorizedClient();
+    expect(first).toBe(second);
   });
 
   it('rebuilds the client after resetAuthorizedClient (e.g. token rotation)', async () => {
     const { getAuthorizedClient, resetAuthorizedClient } = await import('../src/google/auth.js');
     resetAuthorizedClient();
-    const a = getAuthorizedClient();
+    const first = getAuthorizedClient();
     resetAuthorizedClient();
-    const b = getAuthorizedClient();
-    expect(a).not.toBe(b);
+    const second = getAuthorizedClient();
+    expect(first).not.toBe(second);
   });
 });

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -134,10 +134,10 @@ describe('getBrowser — warm reuse', () => {
       launches += 1;
       return Promise.resolve(fake);
     };
-    const a = await getBrowser(launch);
-    const b = await getBrowser(launch);
-    expect(a).toBe(fake);
-    expect(b).toBe(fake);
+    const first = await getBrowser(launch);
+    const second = await getBrowser(launch);
+    expect(first).toBe(fake);
+    expect(second).toBe(fake);
     expect(launches).toBe(1);
   });
 
@@ -211,7 +211,9 @@ describe('openChart — context lifecycle', () => {
   });
 
   it('remote: surfaces a clear error when no remote browser is configured', async () => {
-    await expect(openChart('https://ug/x', 'remote')).rejects.toThrow(/no remote browser is configured/);
+    await expect(openChart('https://ug/x', 'remote')).rejects.toThrow(
+      /no remote browser is configured/
+    );
   });
 });
 

--- a/test/fetcher.test.js
+++ b/test/fetcher.test.js
@@ -6,6 +6,9 @@ import {
   fetchViaUnlocker,
   loadChartPage,
   resolveRemoteEndpoint,
+  getBrowser,
+  openChart,
+  closeSharedBrowser,
 } from '../src/fetcher.js';
 
 const CHART_HTML =
@@ -116,6 +119,99 @@ describe('loadChartPage — strategy wiring (no env)', () => {
     await loadChartPage(makeFakeBrowser(page), 'https://ug/x', 'proxy');
     expect(page._calls.goto).toHaveLength(1);
     expect(page._calls.waitForFunction).toBe(1); // the challenge-clear wait
+  });
+});
+
+describe('getBrowser — warm reuse', () => {
+  afterEach(async () => {
+    await closeSharedBrowser();
+  });
+
+  it('launches once and reuses the same browser while connected', async () => {
+    let launches = 0;
+    const fake = { connected: true, once: () => undefined, close: () => Promise.resolve() };
+    const launch = () => {
+      launches += 1;
+      return Promise.resolve(fake);
+    };
+    const a = await getBrowser(launch);
+    const b = await getBrowser(launch);
+    expect(a).toBe(fake);
+    expect(b).toBe(fake);
+    expect(launches).toBe(1);
+  });
+
+  it('relaunches when the cached browser is no longer connected', async () => {
+    let launches = 0;
+    const dead = { connected: false, once: () => undefined, close: () => Promise.resolve() };
+    const live = { connected: true, once: () => undefined, close: () => Promise.resolve() };
+    const launch = () => {
+      launches += 1;
+      return Promise.resolve(launches === 1 ? dead : live);
+    };
+    expect(await getBrowser(launch)).toBe(dead);
+    expect(await getBrowser(launch)).toBe(live);
+    expect(launches).toBe(2);
+  });
+
+  it('drops the handle when the disconnected event fires', async () => {
+    let launches = 0;
+    let onDisconnect = null;
+    const first = {
+      connected: true,
+      once: (ev, fn) => {
+        if (ev === 'disconnected') onDisconnect = fn;
+      },
+      close: () => Promise.resolve(),
+    };
+    const second = { connected: true, once: () => undefined, close: () => Promise.resolve() };
+    const launch = () => {
+      launches += 1;
+      return Promise.resolve(launches === 1 ? first : second);
+    };
+    await getBrowser(launch);
+    onDisconnect(); // simulate a crash
+    expect(await getBrowser(launch)).toBe(second);
+    expect(launches).toBe(2);
+  });
+});
+
+describe('openChart — context lifecycle', () => {
+  afterEach(async () => {
+    await closeSharedBrowser();
+  });
+
+  it('local: opens a fresh context, and release() closes the context but not the browser', async () => {
+    const page = makeFakePage();
+    let contextClosed = 0;
+    let browserClosed = 0;
+    const context = {
+      newPage: () => page,
+      close: () => {
+        contextClosed += 1;
+        return Promise.resolve();
+      },
+    };
+    const fakeBrowser = {
+      connected: true,
+      once: () => undefined,
+      createBrowserContext: () => Promise.resolve(context),
+      close: () => {
+        browserClosed += 1;
+        return Promise.resolve();
+      },
+    };
+    await getBrowser(() => Promise.resolve(fakeBrowser)); // seed the warm browser
+    const { page: got, release } = await openChart('https://ug/x', 'direct');
+    expect(got).toBe(page);
+    expect(page._calls.goto).toHaveLength(1);
+    await release();
+    expect(contextClosed).toBe(1);
+    expect(browserClosed).toBe(0); // browser stays warm across scrapes
+  });
+
+  it('remote: surfaces a clear error when no remote browser is configured', async () => {
+    await expect(openChart('https://ug/x', 'remote')).rejects.toThrow(/no remote browser is configured/);
   });
 });
 


### PR DESCRIPTION
## What & why

End-to-end scrape latency on the Raspberry Pi was **~40s**. I profiled the path on the Pi and cut the avoidable waits. **No change to extraction or formatting** — purely how the page is fetched and how the browser/auth client are reused.

### Measured on the Pi (Wonderwall)

| Phase (before) | Time |
|---|---|
| Browser launch (every request) | ~3.5s |
| Navigation (`networkidle2` + Cloudflare) | ~12–32s |
| Google Docs | ~4.5s |

Navigation comparison (cold, fresh browser each):

| Variant | total nav |
|---|---|
| `networkidle2` (before) | ~20.8s |
| `domcontentloaded` + existing waits | ~15.3s |

Browser-reuse comparison (3 sequential scrapes):

| Approach | result |
|---|---|
| persistent cookie profile | **75s, hard Cloudflare block** ❌ |
| reused process + fresh context per scrape | 11–15s, all succeed ✅ |

### Changes
- **Warm browser process** reused across scrapes (`getBrowser`/`openChart`/`closeSharedBrowser` in `fetcher.js`); each scrape runs in a fresh **isolated `BrowserContext`** (not a persistent profile — persisting Cloudflare cookies provoked a hard challenge). `scrapeSong` releases the context; the browser stays warm. Relaunches automatically on disconnect.
- **`domcontentloaded`** navigation instead of `networkidle2` (the challenge-clear + `pre` waits remain the real readiness gate).
- **Memoized** the authorized Google OAuth2 client so the access token is reused instead of re-minted each request.

### Live result (full pipeline, on the Pi)
cold 1st **29.9s** → warm 2nd **24.9s** → warm 3rd **21.4s** (was ~40s). First request after boot still pays the one-time launch.

## Tests
- `getBrowser` reuse / relaunch-on-disconnect; `openChart` context lifecycle (release closes the context, not the warm browser); auth client memoization.
- `npm test` green (55 passed, e2e self-skipped), `npm run lint` clean.

## Notes
- Independent of the upcoming formatter redesign.
- Future option (not done): periodic browser recycle to bound Pi memory; single-pass Docs to shave ~1.5s (kept 2-pass for robustness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)