### PR TITLE
fix(formatter): cut trailing Ultimate Guitar chrome from charts

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -23,8 +23,36 @@ const BRACKETED_HEADING = /^\s*\[.+\]\s*$/;
 // note, the [Chords] fingering legend, tuning/tutorial notes. These (and the lines
 // under them, before the first real section) are dropped.
 const PREAMBLE_HEADING = /^(?:capo|chords?|tuning|tutorial|tab)\b/i;
-// Trailing UG boilerplate to stop parsing at (keeps it out of the last section).
-const FOOTER = /thanks for using/i;
+
+// Lines that mark the start of Ultimate Guitar's trailing chrome — ratings, ads,
+// nav, the instrument/chord legend — or a tabber's sign-off / link. Everything
+// from the first such line onward is dropped. Matched against the trimmed line.
+const FOOTER_MARKERS = [
+  /^thanks for using/i,
+  /^tabbed by\b/i,
+  /^create correction$/i,
+  /^report bad tab$/i,
+  /^last update:/i,
+  /^please,? rate/i,
+  /^(?:welcome offer|try now|play next)$/i,
+  /^strumming pattern$/i,
+  /^there is no strumming pattern/i,
+  /^(?:print|x)$/i,
+  /(?:youtube\.com|youtu\.be)/i,
+  /^https?:\/\/\S+$/i,
+  /^-{20,}\s*$/,
+];
+
+/**
+ * Whether a line marks the start of trailing non-chart content (UG chrome, an ad,
+ * a sign-off, a link, or a long divider rule).
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isFooterLine(line) {
+  const trimmed = line.trim();
+  return FOOTER_MARKERS.some((re) => re.test(trimmed));
+}
 
 /** Collapse all runs of whitespace to a single space and trim. */
 const collapseSpaces = (text) => text.trim().replace(/\s+/g, ' ');
@@ -69,7 +97,6 @@ export function parseSections(rawText) {
   const sections = [];
   let current = null;
   for (const raw of lines) {
-    if (FOOTER.test(raw)) break;
     if (isHeading(raw)) {
       const heading = headingName(raw);
       // A preamble heading (Capo/Chords legend/tuning) never opens a section; while
@@ -80,13 +107,15 @@ export function parseSections(rawText) {
       continue;
     }
     if (!current) continue; // drop preamble before the first real heading
+    // Footer is only checked inside the chart, so preamble links/URLs don't end it.
+    if (isFooterLine(raw)) break;
     current.lines.push({ kind: classifyLine(raw), text: raw });
   }
   if (sections.length > 0) return sections;
-  // No headings at all — treat the whole (pre-footer) chart as one section.
+  // No headings at all — treat content up to the footer as one section.
   const body = [];
   for (const raw of lines) {
-    if (FOOTER.test(raw)) break;
+    if (isFooterLine(raw)) break;
     body.push({ kind: classifyLine(raw), text: raw });
   }
   return [{ name: null, heading: null, lines: body }];

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -26,6 +26,29 @@ describe('parseSections', () => {
     expect(JSON.stringify(sections)).not.toMatch(/Thanks for using/);
   });
 
+  it('cuts trailing UG chrome (ratings, ads, nav, links, dividers)', () => {
+    const chart = [
+      '[Verse 1]',
+      'G  D',
+      'real lyric line',
+      '------------------------------------------',
+      'I tabbed this myself, enjoy!',
+      'https://www.youtube.com/watch?v=abc',
+      'X',
+      'Print',
+      'Create correction',
+      'Welcome Offer',
+      'Strumming pattern',
+      'There is no strumming pattern for this song yet. Create and get +5 IQ',
+    ].join('\n');
+    const sections = parseSections(chart);
+    const dump = JSON.stringify(sections);
+    expect(dump).toContain('real lyric line');
+    expect(dump).not.toMatch(
+      /youtube|Welcome Offer|Strumming pattern|Create correction|tabbed this/
+    );
+  });
+
   it('treats a heading-less chart as one untitled section', () => {
     const sections = parseSections(['G  C', 'some words', 'D  Em'].join('\n'));
     expect(sections).toHaveLength(1);


### PR DESCRIPTION
## What & why

A chart (Mickey Mouse Clubhouse – Hot Dog Dance) rendered with a wall of UG page chrome appended after the song: ratings, the "Welcome Offer" ad, the instrument/chord-legend nav (Chords/Guitar/Ukulele/Piano + chord list), "Strumming pattern", a YouTube link, and divider rules. The scraper over-captured page UI into the chart text, and the formatter only knew to stop at "thanks for using".

## Fix
Expand the formatter's footer detection (`isFooterLine` in `src/layout.js`) to stop at the first trailing-chrome marker:
- ratings / "create correction" / "report bad tab" / "last update:" links
- ads / nav: "welcome offer", "try now", "play next"
- "strumming pattern" + "there is no strumming pattern…" block
- standalone URLs (incl. YouTube), and long divider rules (`----…`)
- lone "X"/"Print" UG buttons

Footer is now checked **only inside the chart** (after the first real heading) so preamble links (e.g. a "Tutorial video" URL) don't end parsing early.

## Notes
- Deeper cause is extraction over-capture (the heuristic grabbed page chrome for this non-`<pre>` chart); this is the robust, testable output-side cut.
- The A Team golden fixture is **unchanged**.
- New test covers cutting ratings/ads/nav/links/dividers while keeping real lyrics.
- `format`/`lint`/`test` green (74 passed); branched off the now-merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)