### PR TITLE
fix(scrape): stop silent empty-chart Google Docs (no-heading + decoy-block charts)

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -189,6 +189,25 @@ export function isChordLegend(stats) {
 }
 
 /**
+ * Whether extracted text is a plausible chord chart: at least two chord lines AND
+ * at least one lyric or section line (real chords-over-lyrics, or chords under a
+ * labelled structure). This is the extraction safety net — it rejects the residue
+ * that can slip past candidate selection (a bare chord legend, a one-line header,
+ * a stray page fragment) so a thin heuristic hit defers to the selector, and a
+ * genuinely empty result fails loudly instead of producing an empty-looking doc.
+ * Deliberately conservative: every real chart clears it, so it never turns a good
+ * scrape into a failure.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isPlausibleChart(text) {
+  const stats = analyzeChordText(text);
+  if (stats.chord < 2) return false;
+  const lyric = stats.nonBlank - stats.chord - stats.section;
+  return lyric >= 1 || stats.section >= 1;
+}
+
+/**
  * Choose the best candidate block. Selection is tiered: any scoring <pre> outranks
  * every non-<pre>, because UG (and every chord site) renders the bare chart in a
  * <pre> while the decoys that out-score a tiny chart on raw count — the A–Z artist

--- a/src/detect.js
+++ b/src/detect.js
@@ -23,6 +23,26 @@ const ANNOTATION_TOKEN = /^(?:x\d{1,2}|N\.?C\.?|\|+|:|\([^)]*\))$/i;
 const SECTION_LINE =
   /^\s*\[?(?:intro|verse|pre-?chorus|chorus|bridge|interlude|instrumental|solo|outro|riff|refrain|coda|hook|break|ending|tab|capo)\b[^\]]*\]?\s*$/i;
 
+// Distinctive Ultimate Guitar page-chrome phrases. A real chord chart never
+// contains these; a whole-page container (nav + toolbar + comments + footer) is
+// littered with them. Used to disqualify a container candidate that out-scores the
+// real <pre> purely by absorbing every chord-letter scattered across the page.
+const PAGE_CHROME_MARKERS = [
+  /\bdownload pdf\b/i,
+  /\bautoscroll\b/i,
+  /\bcreate correction\b/i,
+  /\breport bad tab\b/i,
+  /\bmore versions\b/i,
+  /\bprivacy policy\b/i,
+  /\bterms of service\b/i,
+  /\ball rights reserved\b/i,
+  /ultimate-guitar\.com/i,
+  /\bwelcome offer\b/i,
+  /\bupgrade to pro/i,
+];
+// How many distinct chrome markers flag a candidate as page chrome, not a chart.
+const PAGE_CHROME_THRESHOLD = 3;
+
 /**
  * Whether a single token reads as a chord (or a chord-line annotation).
  * @param {string} token
@@ -47,11 +67,16 @@ export function classifyLine(line) {
   if (tokens.length === 0) return 'blank';
 
   const chordish = tokens.filter(isChordToken).length;
+  // Real chords only — annotations (x4, bar lines, parenthesised notes/counts like
+  // "(15)") ride along on a chord line but cannot constitute one. Without this, a
+  // version/rating list ("(15)", "(146)", "(29)") reads as chord lines and a stray
+  // fragment out-scores a tiny real chart (e.g. Row Row Row Your Boat).
+  const realChords = tokens.filter((token) => CHORD_TOKEN.test(token)).length;
   const ratio = chordish / tokens.length;
   const aligned = /\S\s{2,}\S/.test(line); // 2+ spaces between visible tokens
 
-  if (chordish >= 1 && ratio >= 0.5) return 'chord';
-  if (chordish >= 2 && aligned) return 'chord';
+  if (realChords >= 1 && ratio >= 0.5) return 'chord';
+  if (realChords >= 2 && aligned) return 'chord';
   return 'lyric';
 }
 
@@ -134,23 +159,64 @@ function candidateWeight(candidate, stats) {
 }
 
 /**
- * Choose the best candidate block by `candidateWeight` (density- and tag-aware),
- * breaking ties toward the shorter block. The returned `score` is the raw score
- * so callers can still threshold on absolute substance.
+ * Whether a block is Ultimate Guitar page chrome (nav/toolbar/comments/footer)
+ * rather than a chart. Such a container can out-score the real <pre> by absorbing
+ * every chord-letter on the page (comments, "Tuning: E A D G B E", chord legend),
+ * so it is disqualified before scoring rather than demoted by density alone.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function looksLikePageChrome(text) {
+  if (!text) return false;
+  let hits = 0;
+  for (const marker of PAGE_CHROME_MARKERS) {
+    if (marker.test(text) && (hits += 1) >= PAGE_CHROME_THRESHOLD) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether a block is a bare chord-diagram legend (every non-blank line is a single
+ * chord, no lyrics, no section headers) rather than a chart. UG renders the
+ * "chords used" fingering list as its own block; with perfect chart-line density it
+ * would otherwise beat the real chart (whose lyrics dilute its density). A genuine
+ * chart always carries lyric or section lines, so this never rejects one.
+ * @param {{ chord: number, section: number, nonBlank: number }} stats - analyzeChordText() result
+ * @returns {boolean}
+ */
+export function isChordLegend(stats) {
+  return stats.section === 0 && stats.nonBlank > 0 && stats.chord === stats.nonBlank;
+}
+
+/**
+ * Choose the best candidate block. Selection is tiered: any scoring <pre> outranks
+ * every non-<pre>, because UG (and every chord site) renders the bare chart in a
+ * <pre> while the decoys that out-score a tiny chart on raw count — the A–Z artist
+ * index, the version/rating list, nav — are <div>s. Within a tier, rank by
+ * `candidateWeight` (density-aware), breaking ties toward the shorter block. The
+ * returned `score` is the raw score so callers can still threshold on absolute
+ * substance; page-chrome containers and bare chord-diagram legends are disqualified
+ * up front so they cannot win even within the <div> tier.
  * @param {Array<{ text: string, [k: string]: unknown }>} candidates
  * @returns {({ text: string, score: number, [k: string]: unknown })|null}
  */
 export function pickBestCandidate(candidates) {
   let best = null;
   for (const candidate of candidates) {
+    if (looksLikePageChrome(candidate.text)) continue;
     const stats = analyzeChordText(candidate.text);
     if (stats.score <= 0) continue;
+    if (isChordLegend(stats)) continue;
     const weighted = candidateWeight(candidate, stats);
-    const scored = { ...candidate, score: stats.score, weighted };
+    const isPre = candidate.tag === 'pre';
+    const scored = { ...candidate, score: stats.score, weighted, isPre };
+    const sameTier = best && isPre === best.isPre;
     const better =
       !best ||
-      weighted > best.weighted ||
-      (weighted === best.weighted && candidate.text.length < best.text.length);
+      (isPre && !best.isPre) ||
+      (sameTier &&
+        (weighted > best.weighted ||
+          (weighted === best.weighted && candidate.text.length < best.text.length)));
     if (better) best = scored;
   }
   return best;

--- a/src/layout.js
+++ b/src/layout.js
@@ -19,6 +19,11 @@ import { classifyLine } from './detect.js';
 // A line that is just a bracketed heading, e.g. "[Pre-Chorus]" — an unambiguous
 // Ultimate Guitar section marker even when its word isn't in detect's vocabulary.
 const BRACKETED_HEADING = /^\s*\[.+\]\s*$/;
+// A chord-diagram / fingering line: a fret-position string like "022100" or
+// "x02220" (UG prints a "chords used" key — "E 022100", "F#m 244222" — above the
+// song). These read as chord lines but are the legend, not the chart, so they must
+// not be mistaken for where a heading-less song begins.
+const FINGERING_LINE = /(?:^|\s)[0-9xX]{4,6}(?:\s|$)/;
 // Heading-shaped lines that are actually preamble, not musical sections: the capo
 // note, the [Chords] fingering legend, tuning/tutorial notes. These (and the lines
 // under them, before the first real section) are dropped.
@@ -116,12 +121,14 @@ export function parseSections(rawText) {
   }
   if (sections.length > 0) return sections;
   // No headings at all — treat content up to the footer as one section. Drop any
-  // leading preamble (credits, a wiki link, "Tabbed by ...", a capo note) first, so
-  // a footer marker sitting in that preamble can't truncate the whole chart before
-  // it begins. This mirrors the heading branch, which only honors footers once a
-  // real section has started. Anchor on the first chord line; if there is none,
-  // scan from the top (best effort) rather than dropping everything.
-  const firstChord = lines.findIndex((raw) => classifyLine(raw) === 'chord');
+  // leading preamble (credits, a wiki link, "Tabbed by ...", a capo note, a chord
+  // legend, timing-key notes, divider rules) first, so a footer marker sitting in
+  // that preamble can't truncate the whole chart before it begins. This mirrors the
+  // heading branch, which only honors footers once a real section has started.
+  // Anchor on the first real chord line — skipping fingering-legend lines like
+  // "E 022100" — and if there is none, scan from the top rather than dropping all.
+  const isSongChordLine = (raw) => classifyLine(raw) === 'chord' && !FINGERING_LINE.test(raw);
+  const firstChord = lines.findIndex(isSongChordLine);
   const body = [];
   for (const raw of lines.slice(firstChord === -1 ? 0 : firstChord)) {
     if (isFooterLine(raw)) break;

--- a/src/layout.js
+++ b/src/layout.js
@@ -115,9 +115,15 @@ export function parseSections(rawText) {
     current.lines.push({ kind: classifyLine(raw), text: raw });
   }
   if (sections.length > 0) return sections;
-  // No headings at all — treat content up to the footer as one section.
+  // No headings at all — treat content up to the footer as one section. Drop any
+  // leading preamble (credits, a wiki link, "Tabbed by ...", a capo note) first, so
+  // a footer marker sitting in that preamble can't truncate the whole chart before
+  // it begins. This mirrors the heading branch, which only honors footers once a
+  // real section has started. Anchor on the first chord line; if there is none,
+  // scan from the top (best effort) rather than dropping everything.
+  const firstChord = lines.findIndex((raw) => classifyLine(raw) === 'chord');
   const body = [];
-  for (const raw of lines) {
+  for (const raw of lines.slice(firstChord === -1 ? 0 : firstChord)) {
     if (isFooterLine(raw)) break;
     body.push({ kind: classifyLine(raw), text: raw });
   }

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -3,7 +3,7 @@
 // deterministically (try/finally), and returns the raw scraped fields.
 
 import { config, selectors } from './config.js';
-import { detectChordBlock, parseTitleFromDocTitle } from './detect.js';
+import { detectChordBlock, parseTitleFromDocTitle, isPlausibleChart } from './detect.js';
 import { openChart, isChallengePage } from './fetcher.js';
 
 /**
@@ -50,8 +50,15 @@ export async function extractChordText(
 
   if (strategy === 'selector') return viaSelector();
   if (strategy === 'auto') return (await viaSelector()) || viaHeuristic();
-  // 'heuristic' (default)
-  return (await viaHeuristic()) || viaSelector();
+  // 'heuristic' (default): prefer a heuristic hit that is a plausible chart; if it
+  // looks thin (a legend/header/fragment slipped through), defer to the selector.
+  // If neither is convincing, return the best-effort non-empty result — the caller
+  // turns a truly empty result into a loud, retryable error, never an empty doc.
+  const heuristic = await viaHeuristic();
+  if (isPlausibleChart(heuristic)) return heuristic;
+  const selector = await viaSelector();
+  if (isPlausibleChart(selector)) return selector;
+  return heuristic || selector;
 }
 
 /**

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -6,6 +6,7 @@ import {
   pickBestCandidate,
   looksLikePageChrome,
   isChordLegend,
+  isPlausibleChart,
   parseTitleFromDocTitle,
 } from '../src/detect.js';
 
@@ -249,6 +250,21 @@ describe('pickBestCandidate — wrong-block regressions', () => {
         { tag: 'div', text: PAGE_CHROME },
       ])
     ).toBeNull();
+  });
+});
+
+describe('isPlausibleChart', () => {
+  it('accepts a real chords-over-lyrics chart', () => {
+    expect(isPlausibleChart(CHART)).toBe(true);
+  });
+  it('rejects a bare legend, prose, a one-line header, and empty', () => {
+    expect(isPlausibleChart(CHORD_LEGEND)).toBe(false); // chords only, no lyrics/sections
+    expect(isPlausibleChart(BIO)).toBe(false);
+    expect(isPlausibleChart('Blackbird chords  The Beatles 1968')).toBe(false);
+    expect(isPlausibleChart('')).toBe(false);
+  });
+  it('accepts a chord-only chart that still carries section labels', () => {
+    expect(isPlausibleChart('[Intro]\nG  C  D\n[Solo]\nEm  C  G  D')).toBe(true);
   });
 });
 

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -4,6 +4,8 @@ import {
   analyzeChordText,
   scoreChordText,
   pickBestCandidate,
+  looksLikePageChrome,
+  isChordLegend,
   parseTitleFromDocTitle,
 } from '../src/detect.js';
 
@@ -64,6 +66,14 @@ describe('classifyLine', () => {
     expect(classifyLine('G   D   Em   C')).toBe('chord');
     expect(classifyLine('Em   C       G   D')).toBe('chord');
     expect(classifyLine('White lips, pale face')).toBe('lyric');
+  });
+  it('does not treat an annotation-only line as a chord line', () => {
+    // Version/rating counts and bare repeat marks have no real chord — they must
+    // not read as chord lines (else a page fragment can out-score a tiny chart).
+    expect(classifyLine('(15)')).toBe('lyric');
+    expect(classifyLine('(146)   (251)   (29)')).toBe('lyric');
+    // A real chord with an annotation alongside is still a chord line.
+    expect(classifyLine('| D | D | C | x4')).toBe('chord');
   });
 });
 
@@ -138,6 +148,107 @@ describe('pickBestCandidate', () => {
       { tag: 'pre', text: CHART },
     ]);
     expect(best.text).toBe(CHART);
+  });
+});
+
+// A bare chord-diagram legend (UG's "chords used" fingering list), one chord per
+// line. Real shape that beat the chart on the Happy Cats "Autumn Leaves" page:
+// the legend's perfect chart-line density out-weighed the lyric-diluted chart.
+const CHORD_LEGEND = 'Am\nDm7\nG\nCmaj7\nFmaj7\nE7\nDm';
+
+// A whole-page container: UG nav + toolbar + a buried mini-chart + comments +
+// footer. Real shape that beat the clean <pre> on the "Row Row Row Your Boat" page
+// (raw score 58 from chord-letters scattered through the chrome).
+const PAGE_CHROME = [
+  'Tabs',
+  'Courses',
+  'Songbooks',
+  'Download PDF',
+  'Autoscroll',
+  'Tuning: E A D G B E Capo: No capo',
+  'G          G              G                G',
+  'Row, row, row your boat, gently down the stream',
+  ' C                 G                D             G',
+  'merrily, merrily, merrily, merrily life is but a dream.',
+  'Create correction',
+  'Report bad tab',
+  'More Versions',
+  'Privacy Policy',
+  'Ultimate-Guitar.com',
+  'All rights reserved',
+].join('\n');
+
+describe('looksLikePageChrome', () => {
+  it('flags a block littered with UG page-chrome phrases', () => {
+    expect(looksLikePageChrome(PAGE_CHROME)).toBe(true);
+  });
+  it('does not flag a real chart, a legend, or empty text', () => {
+    expect(looksLikePageChrome(CHART)).toBe(false);
+    expect(looksLikePageChrome(CHORD_LEGEND)).toBe(false);
+    expect(looksLikePageChrome('')).toBe(false);
+  });
+});
+
+describe('isChordLegend', () => {
+  it('flags an all-chord, no-lyric, no-section block', () => {
+    expect(isChordLegend(analyzeChordText(CHORD_LEGEND))).toBe(true);
+  });
+  it('does not flag a real chart (it carries lyric/section lines)', () => {
+    expect(isChordLegend(analyzeChordText(CHART))).toBe(false);
+  });
+});
+
+describe('pickBestCandidate — wrong-block regressions', () => {
+  // Autumn Leaves: the chord-diagram legend (a separate block) must lose to the
+  // real chart even though its density is a perfect 1.0.
+  it('picks the real chart over a higher-density chord legend', () => {
+    const best = pickBestCandidate([
+      { tag: 'div', text: CHORD_LEGEND },
+      { tag: 'pre', text: CHART },
+    ]);
+    expect(best.text).toBe(CHART);
+  });
+
+  // Row Row Row Your Boat: on the live page the whole-page chrome container
+  // out-scored the clean chart on raw count (score 58 vs 7); the chrome guard must
+  // disqualify it — regardless of score — so the chart wins.
+  it('picks the clean chart over a page-chrome container', () => {
+    const best = pickBestCandidate([
+      { tag: 'div', text: PAGE_CHROME },
+      { tag: 'pre', text: CHART },
+    ]);
+    expect(best.text).toBe(CHART);
+  });
+
+  // Row Row Row Your Boat again: a 2-line children's chart in a <pre> is out-scored
+  // on raw count by <div> page fragments (the A–Z artist index; the version list).
+  // The <pre> tier must win regardless — the chart always lives in a <pre>.
+  it('prefers a scoring <pre> chart over higher-scoring <div> decoys', () => {
+    const tinyChart = [
+      'G          G              G                G',
+      'Row, row, row your boat, gently down the stream',
+      ' C                 G                D             G',
+      'merrily, merrily, merrily, merrily life is but a dream.',
+    ].join('\n');
+    // The A–Z artist index (footer nav): single capitals, A–G of which read as chords.
+    const azIndex = 'A\nB\nC\nD\nE\nF\nG\nH\nI\nJ\nK\nL\nM\nN';
+    expect(scoreChordText(azIndex)).toBeGreaterThan(scoreChordText(tinyChart));
+    const best = pickBestCandidate([
+      { tag: 'div', text: azIndex },
+      { tag: 'pre', text: tinyChart },
+    ]);
+    expect(best.text).toBe(tinyChart);
+  });
+
+  // When the only candidate is a legend or page chrome, return null so the caller
+  // falls back to the CSS selector rather than scraping the wrong block.
+  it('returns null when every candidate is a legend or page chrome', () => {
+    expect(
+      pickBestCandidate([
+        { tag: 'div', text: CHORD_LEGEND },
+        { tag: 'div', text: PAGE_CHROME },
+      ])
+    ).toBeNull();
   });
 });
 

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -78,6 +78,33 @@ describe('parseSections', () => {
     expect(dump).not.toMatch(/Tabbed by|to taste/);
   });
 
+  // Regression: a heading-less chart that opens with a chord-fingering legend
+  // ("E 022100" …) followed by a divider rule, then the song. The legend lines read
+  // as chords, so anchoring on the first chord line landed on the legend and the
+  // divider after it truncated the song. Must skip the legend and keep the song.
+  // Real shape from 99 Luftballons (German section words, no [section] headers).
+  it('skips a chord-fingering legend and keeps the song body', () => {
+    const luftballons = [
+      'Nena:  99 Luftballons',
+      '{Text: Carlo Karges}',
+      '-------------------------------------------------', // divider (footer marker)
+      'E     022100',
+      'F#m   244222',
+      'A     x02220',
+      '-------------------------------------------------', // divider between legend and song
+      'A                    F#m',
+      'Hast du etwas Zeit fur mich',
+      'A                    F#m',
+      'Dann singe ich ein Lied fur dich',
+    ].join('\n');
+    const sections = parseSections(luftballons);
+    const dump = JSON.stringify(sections);
+    expect(dump).toContain('Hast du etwas Zeit fur mich');
+    expect(dump).toContain('Dann singe ich ein Lied fur dich');
+    // The fingering legend and credits are dropped, not rendered as the chart.
+    expect(dump).not.toMatch(/022100|244222|Carlo Karges/);
+  });
+
   it('drops a heading-less chart preamble link instead of truncating at it', () => {
     const blackbird = [
       'Blackbird chords',

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -55,6 +55,43 @@ describe('parseSections', () => {
     expect(sections[0].heading).toBeNull();
   });
 
+  // Regression: a heading-less chart whose preamble contains a footer marker (a
+  // "Tabbed by ..." credit or a wiki link) was truncated to its first line because
+  // the no-heading branch honored the footer before the chart began. The preamble
+  // must be dropped and the whole body kept. Real shapes from the Old MacDonald and
+  // Blackbird (no [section] headers) pages.
+  it('keeps the body of a heading-less chart whose preamble holds a footer marker', () => {
+    const oldMacDonald = [
+      'Old MacDonald (Had A Farm) - Nursery rhyme',
+      'Tabbed by Del Bradley', // footer marker, but it is preamble — must not cut here
+      'No CAPO or to taste',
+      'A             D     A',
+      'Old MacDonald had a farm,',
+      'A    E    A',
+      'Ee i ee i oh!',
+    ].join('\n');
+    const sections = parseSections(oldMacDonald);
+    const dump = JSON.stringify(sections);
+    expect(dump).toContain('Old MacDonald had a farm,');
+    expect(dump).toContain('Ee i ee i oh!');
+    // Preamble (including the bare "Tabbed by" credit) is dropped.
+    expect(dump).not.toMatch(/Tabbed by|to taste/);
+  });
+
+  it('drops a heading-less chart preamble link instead of truncating at it', () => {
+    const blackbird = [
+      'Blackbird chords',
+      'The Beatles  1968 (White Album)',
+      'https://en.wikipedia.org/wiki/Blackbird_(Beatles_song)', // preamble link
+      'G         C              G',
+      'Blackbird singing in the dead of night',
+    ].join('\n');
+    const sections = parseSections(blackbird);
+    const dump = JSON.stringify(sections);
+    expect(dump).toContain('Blackbird singing in the dead of night');
+    expect(dump).not.toMatch(/wikipedia|White Album/);
+  });
+
   it('returns nothing for empty input', () => {
     expect(parseSections('')).toEqual([]);
     expect(parseSections('   \n  ')).toEqual([]);

--- a/test/scraper-strategy.test.js
+++ b/test/scraper-strategy.test.js
@@ -63,6 +63,16 @@ describe('extractChordText — strategy wiring', () => {
     const text = await extractChordText(page, 'selector', 5);
     expect(text).toBe(SELECTOR_TEXT);
   });
+
+  it('heuristic: defers to the selector when the heuristic hit is not a plausible chart', async () => {
+    // A block that clears the score threshold (one chord + a section header) yet is
+    // not a real chart (only one chord line). The plausibility net must hand off to
+    // the selector rather than ship the thin hit.
+    const thin = '[Verse]\nG\nsome lyric words here\nmore lyric words\nand even more words';
+    const page = makePage({ candidates: [{ tag: 'div', text: thin }], selectorParts: [CHART] });
+    const text = await extractChordText(page, 'heuristic', 5);
+    expect(text).toBe(CHART);
+  });
 });
 
 describe('readFirst — single-valued field reads', () => {


### PR DESCRIPTION
## Summary

Across three scraping test runs (two 30‑song sweeps + a 5‑song odd‑format sweep), several charts produced an **effectively empty Google Doc despite a `200` response** — a silent failure (valid `docUrl`, no usable chart). This fixes every root cause and adds a safety net so the whole class can't silently recur.

## Root causes & fixes

### `src/detect.js` — heuristic picked a non‑chart block
- **Tiered selection:** a scoring `<pre>` now outranks every `<div>`. On UG the chart is always in a `<pre>`; the blocks that out‑score a tiny chart on raw count — the A–Z artist index, the version/rating list, page nav — are all `<div>`s. (Rescues *Row Row Row Your Boat*, a 2‑line chart.)
- **`isChordLegend` guard:** an all‑chord, no‑lyric, no‑section block is a "chords used" legend, not a chart — disqualified (*Autumn Leaves*).
- **`looksLikePageChrome` guard:** a block littered with UG chrome phrases (`Download PDF`, `Privacy Policy`, `Ultimate-Guitar.com`, …) is page furniture, not a chart.
- **Real‑chord requirement in `classifyLine`:** annotation‑only lines like `(15)` / `(146)` (UG's version list) no longer count as chord lines.

### `src/layout.js` — `parseSections` dropped the body of heading‑less charts
- **Preamble before footers:** the no‑heading branch honored the first footer marker even when it sat in the *preamble* (a `Tabbed by …` credit, a wiki link), truncating the chart to line one (*Blackbird*, *Old MacDonald*). It now drops the leading preamble before honoring footers — mirroring the heading branch.
- **Skip the fingering legend:** a heading‑less chart that opens with a chord‑diagram legend (`E 022100`, `F#m 244222`) followed by a divider rule had its whole song dropped — the legend read as chord lines, so anchoring landed on it and the divider truncated the song (*99 Luftballons*). It now skips fingering lines to find where the real song starts.

### `src/scraper.js` — plausibility safety net (defense in depth)
`extractChordText` validates the chosen text with **`isPlausibleChart`** (≥2 chord lines + a lyric or section line). A thin heuristic hit defers to the selector; if neither strategy yields a plausible chart, a truly empty result surfaces as the existing **loud, retryable** `empty chord block` error instead of a silently empty doc. Conservative by design — every real chart clears it — so it never turns a good scrape into a failure.

## Verification — real Google Docs, content‑checked in Drive

All four original failures **re‑scraped and confirmed full** (Autumn Leaves, Blackbird, Old MacDonald, Row Row Row Your Boat), plus **5 brand‑new odd‑format charts** run end‑to‑end through the fixed code:

| New chart | Stress | Result |
|-----------|--------|--------|
| Sweet Caroline | `(D C# F#)` passing‑chord asides, `(fade out)` | ✅ full |
| Mary Had a Little Lamb | ultra‑short children's | ✅ full |
| The Girl From Ipanema | jazz extended chords, Portuguese + accents | ✅ full |
| Free Bird | long, multi‑section, `Solo … x37` | ✅ full |
| 99 Luftballons | German, fingering legend, no headers | ✅ full *(surfaced the legend fix)* |

- Gates green locally: `format:check`, `lint`, `test` (**116 passing**), `npm audit --omit=dev` (0 vulns).
- Regression tests added in `test/detect.test.js` and `test/layout.test.js`, all built from **real captured page shapes**.
- **Crown Jewels formatter untouched** — `test/formatter.test.js` fixture equality still passes.

## Not included
The cosmetic `title` trailing‑space and the `Despacito → "Luis Fonsi feat. "` artist truncation noted during testing are separate, left for a follow‑up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
