### PR TITLE
fix(scrape): clean title trailing space + rebuild split feat. artist

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -40,6 +40,41 @@ export async function readFirst(page, selector) {
 }
 
 /**
+ * Strip the trailing " Chords" affordance UG appends to the song's <h1> and trim
+ * surrounding whitespace. The legacy `.replace(' Chords', '')` left the title's
+ * trailing space (the <h1> is "Despacito Chords "), so the returned title carried a
+ * stray space. Anchored to the end, so a song whose name contains "chord" is safe.
+ * @param {string} rawTitle - the raw <h1> textContent
+ * @returns {string} the cleaned song title
+ */
+export function cleanTitle(rawTitle) {
+  return (rawTitle ?? '').replace(/\s*Chords?\s*$/i, '').trim();
+}
+
+/**
+ * Compose the artist credit from the page's artist-link texts. UG repeats the same
+ * artist link (breadcrumb + header), so identical texts are de-duplicated; but a
+ * "feat." collaboration is split across separate links whose texts already carry the
+ * connector ("Luis Fonsi feat. ", "Daddy Yankee"), so the distinct texts are
+ * concatenated in order to rebuild the full credit. readFirst() alone dropped the
+ * featured artist ("Luis Fonsi feat. ").
+ * @param {string[]} texts - textContent of every artist link, in document order
+ * @returns {string} the composed artist credit (untrimmed)
+ */
+export function joinDistinctArtists(texts) {
+  const seen = new Set();
+  let out = '';
+  for (const raw of texts ?? []) {
+    const text = raw ?? '';
+    const key = text.trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out += text;
+  }
+  return out;
+}
+
+/**
  * Resolve the chord-chart text using the configured strategy.
  * @param {import('puppeteer').Page} page
  * @param {string} [strategy=config.scrapeStrategy]
@@ -126,11 +161,13 @@ async function attemptScrape(url) {
 
     const rawText = await extractChordText(page);
     const rawTitle = await readFirst(page, selectors.title);
-    const rawArtist = await readFirst(page, selectors.artist);
+    const artistTexts = await readTexts(page, selectors.artist);
 
-    // Legacy cleaning: strip " Chords" from the title and "Edit" from the artist.
-    let title = rawTitle.replace(' Chords', '');
-    let artist = rawArtist.replace('Edit', '');
+    // Clean the scraped fields: drop the trailing " Chords" from the title and the
+    // stray "Edit" affordance from the artist, compose a "feat." credit split across
+    // multiple artist links (joinDistinctArtists), and trim both.
+    let title = cleanTitle(rawTitle);
+    let artist = joinDistinctArtists(artistTexts).replace('Edit', '').trim();
     if (!title || !artist) {
       const fromDoc = parseTitleFromDocTitle(await page.title());
       if (fromDoc) ({ title, artist } = fromDoc);
@@ -151,12 +188,15 @@ async function attemptScrape(url) {
 }
 
 /**
- * The document title the legacy code produced: `${title}- ${artist}` (note: no
- * space before the dash). Preserved exactly because it feeds the title placeholder.
+ * The document title `${title} - ${artist}`, matching the template placeholder
+ * "Song Title - Artist Name". (Legacy used `${title}- ${artist}` and relied on the
+ * title keeping a trailing space; the title is now trimmed, so the separating space
+ * is explicit. For a clean single-artist title the output is byte-identical, e.g.
+ * "Hurt - Johnny Cash".)
  * @param {string} title - the song title
  * @param {string} artist - the artist name
  * @returns {string} the composed document title
  */
 export function buildDocTitle(title, artist) {
-  return `${title}- ${artist}`;
+  return `${title} - ${artist}`;
 }

--- a/test/scraper-strategy.test.js
+++ b/test/scraper-strategy.test.js
@@ -1,4 +1,11 @@
-import { extractChordText, readFirst, isRetryableScrapeError } from '../src/scraper.js';
+import {
+  extractChordText,
+  readFirst,
+  isRetryableScrapeError,
+  cleanTitle,
+  joinDistinctArtists,
+  buildDocTitle,
+} from '../src/scraper.js';
 
 // A strong chord-chart candidate (chords-above-lyrics with section headers).
 const CHART = `[Verse 1]
@@ -85,6 +92,50 @@ describe('readFirst — single-valued field reads', () => {
   it('returns an empty string when nothing matches', async () => {
     const page = makePage({ selectorParts: [] });
     expect(await readFirst(page, 'h1')).toBe('');
+  });
+});
+
+describe('cleanTitle', () => {
+  it('strips the trailing " Chords" and surrounding whitespace', () => {
+    // Real <h1> shapes: "Despacito Chords ", "Hurt Chords " (note the trailing space).
+    expect(cleanTitle('Despacito Chords ')).toBe('Despacito');
+    expect(cleanTitle('Hurt Chords ')).toBe('Hurt');
+    expect(cleanTitle('99 Luftballons Chords')).toBe('99 Luftballons');
+  });
+  it('only strips a trailing "Chords", not the word inside a title', () => {
+    expect(cleanTitle('The Lost Chord Chords ')).toBe('The Lost Chord');
+  });
+  it('handles empty / missing input', () => {
+    expect(cleanTitle('')).toBe('');
+    expect(cleanTitle(null)).toBe('');
+  });
+});
+
+describe('joinDistinctArtists', () => {
+  it('rebuilds a feat. credit split across links (Despacito)', () => {
+    // Real artist-link texts: the connector is baked into the first link.
+    expect(joinDistinctArtists(['Luis Fonsi feat. ', 'Daddy Yankee'])).toBe(
+      'Luis Fonsi feat. Daddy Yankee'
+    );
+  });
+  it('de-duplicates a repeated single artist link', () => {
+    expect(joinDistinctArtists(['Misc Children', 'Misc Children', 'Misc Children'])).toBe(
+      'Misc Children'
+    );
+    expect(joinDistinctArtists(['Johnny Cash'])).toBe('Johnny Cash');
+  });
+  it('ignores blank links and empty input', () => {
+    expect(joinDistinctArtists(['', '  ', 'Nena'])).toBe('Nena');
+    expect(joinDistinctArtists([])).toBe('');
+  });
+});
+
+describe('buildDocTitle', () => {
+  it('joins title and artist with " - " (placeholder style)', () => {
+    expect(buildDocTitle('Hurt', 'Johnny Cash')).toBe('Hurt - Johnny Cash');
+    expect(buildDocTitle('Despacito', 'Luis Fonsi feat. Daddy Yankee')).toBe(
+      'Despacito - Luis Fonsi feat. Daddy Yankee'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Two cosmetic field bugs noticed during the scrape-testing sessions, fixed together. Both are about the `title`/`artist` fields (the chord extraction is unaffected).

## Bugs & fixes

### 1. Trailing space in `title`
UG's song `<h1>` is `"Despacito Chords "` (trailing space), so the legacy `rawTitle.replace(' Chords', '')` left a stray trailing space on every title (`"Despacito "`, `"Hurt "`). New **`cleanTitle()`** strips a trailing `Chords` (anchored to the end, case-insensitive) and trims — so a song whose name *contains* "chord" (e.g. *The Lost Chord*) is safe.

### 2. `feat.` artist truncated
A collaboration is split across **separate** UG artist links — captured live for Despacito:
```
artist links = ["Luis Fonsi feat. ", "Daddy Yankee"]
```
The connector is baked into the first link, and `readFirst()` took only it → `"Luis Fonsi feat. "` (featured artist dropped). New **`joinDistinctArtists()`** concatenates the *distinct* link texts (de-duping UG's repeated links for single-artist songs) → `"Luis Fonsi feat. Daddy Yankee"`.

### `buildDocTitle` spacing
Now joins with `" - "` (matching the template placeholder `"Song Title - Artist Name"`) instead of relying on the title's old trailing space. For a clean single-artist title the doc name is **byte-identical** (`"Hurt - Johnny Cash"`), so existing docs are unaffected; `feat.` docs go from `"Despacito - Luis Fonsi feat. "` to `"Despacito - Luis Fonsi feat. Daddy Yankee"`.

## Verification
- Unit tests in `test/scraper-strategy.test.js` for `cleanTitle`, `joinDistinctArtists`, and `buildDocTitle`, built from the **real captured `<h1>` and artist-link shapes**.
- Live-checked on the real Despacito and Hurt pages through `scrapeSong` (see PR thread).
- Gates green: `format:check`, `lint`, `test` (**177 passing**), `npm audit --omit=dev` (0 vulns).
- **Crown Jewels formatter untouched** — its fixture test still passes (`buildDocTitle` is not referenced by any formatter test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
